### PR TITLE
feat: post-merge improvements (deadline, FTS recall, DB size)

### DIFF
--- a/cmd/session-indexer/main.go
+++ b/cmd/session-indexer/main.go
@@ -107,12 +107,12 @@ func main() {
 				return err
 			}
 			defer d.Close()
-			st, err := search.GetStats(d)
+			st, err := search.GetStats(d, dbPath)
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Sessions indexed: %d\nChunks total:     %d\nWith embeddings:  %d (%d pending)\nOldest entry:     %s\nNewest entry:     %s\n",
-				st.Sessions, st.Chunks, st.Embedded, st.Pending, st.Oldest, st.Newest)
+			fmt.Printf("Sessions indexed: %d\nChunks total:     %d\nWith embeddings:  %d (%d pending)\nOldest entry:     %s\nNewest entry:     %s\nDB size:          %s\n",
+				st.Sessions, st.Chunks, st.Embedded, st.Pending, st.Oldest, st.Newest, st.DBSize)
 			return nil
 		},
 	}

--- a/cmd/session-indexer/main.go
+++ b/cmd/session-indexer/main.go
@@ -44,8 +44,11 @@ func main() {
 			if err != nil {
 				return err
 			}
+			// No embeddings at all and nothing deferred: either Ollama was
+			// unavailable or every Embed call failed. Don't claim a cause we
+			// can't confirm — just point at the backfill command.
 			if res.Embedded == 0 && res.ChunksInserted > 0 && res.Deferred == 0 {
-				fmt.Fprintln(os.Stderr, "warn: ollama unavailable, indexed without embeddings")
+				fmt.Fprintf(os.Stderr, "warn: indexed without embeddings — run: session-indexer embed --db %s\n", dbPath)
 			}
 			if res.Deferred > 0 {
 				fmt.Fprintf(os.Stderr, "warn: %d chunks deferred (run: session-indexer embed --db %s)\n",

--- a/cmd/session-indexer/main.go
+++ b/cmd/session-indexer/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/valpere/session-indexer/internal"
@@ -34,15 +36,23 @@ func main() {
 				return fmt.Errorf("--db is required")
 			}
 			emb := embed.NewClient()
-			res, err := mine.Run(dbPath, args[0], emb)
+			// 50s deadline leaves headroom under the 60s Stop-hook budget;
+			// chunks past the deadline are stored but deferred to `embed`.
+			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
+			defer cancel()
+			res, err := mine.Run(ctx, dbPath, args[0], emb)
 			if err != nil {
 				return err
 			}
-			if res.Embedded == 0 && res.ChunksInserted > 0 {
+			if res.Embedded == 0 && res.ChunksInserted > 0 && res.Deferred == 0 {
 				fmt.Fprintln(os.Stderr, "warn: ollama unavailable, indexed without embeddings")
 			}
-			fmt.Printf("mined: %d chunks inserted, %d embedded, %d skipped\n",
-				res.ChunksInserted, res.Embedded, res.Skipped)
+			if res.Deferred > 0 {
+				fmt.Fprintf(os.Stderr, "warn: %d chunks deferred (run: session-indexer embed --db %s)\n",
+					res.Deferred, dbPath)
+			}
+			fmt.Printf("mined: %d chunks inserted, %d embedded, %d skipped, %d deferred\n",
+				res.ChunksInserted, res.Embedded, res.Skipped, res.Deferred)
 			return nil
 		},
 	}

--- a/internal/mine/mine.go
+++ b/internal/mine/mine.go
@@ -1,6 +1,7 @@
 package mine
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,11 +16,17 @@ type Result struct {
 	ChunksInserted int
 	Embedded       int
 	Skipped        int
+	Deferred       int // inserted but not embedded — ctx deadline hit; backfill via `embed`
 }
 
-// Run parses jsonlPath, stores chunks in dbPath, and embeds new chunks
-// when emb is available. Idempotent: re-mining the same file inserts nothing.
-func Run(dbPath, jsonlPath string, emb embed.Embedder) (Result, error) {
+// Run parses jsonlPath, stores chunks in dbPath, and embeds new chunks when
+// emb is available. Idempotent: re-mining the same file inserts nothing.
+//
+// Storing is split from embedding so a ctx deadline never loses a chunk:
+// phase 1 inserts every chunk (fast), phase 2 embeds the newly-inserted ones
+// and defers the rest when ctx is done. Deferred chunks have no embedding row
+// and are backfilled by the `embed` subcommand once Ollama is reachable.
+func Run(ctx context.Context, dbPath, jsonlPath string, emb embed.Embedder) (Result, error) {
 	var res Result
 	f, err := os.Open(jsonlPath)
 	if err != nil {
@@ -40,7 +47,13 @@ func Run(dbPath, jsonlPath string, emb embed.Embedder) (Result, error) {
 	}
 	defer d.Close()
 
+	// Phase 1: store all chunks (fast, idempotent). Collect new ones to embed.
 	available := emb.Available()
+	type toEmbed struct {
+		id      int64
+		content string
+	}
+	var pending []toEmbed
 	for _, c := range chunks {
 		id, inserted, err := db.InsertChunk(d, c)
 		if err != nil {
@@ -50,15 +63,24 @@ func Run(dbPath, jsonlPath string, emb embed.Embedder) (Result, error) {
 			continue
 		}
 		res.ChunksInserted++
-		if !available {
+		if available {
+			pending = append(pending, toEmbed{id, c.Content})
+		}
+	}
+
+	// Phase 2: embed new chunks, respecting the ctx deadline. Once ctx is done,
+	// remaining chunks are deferred (not embedded) — never abort the mine.
+	for _, p := range pending {
+		if ctx.Err() != nil {
+			res.Deferred++
 			continue
 		}
-		vec, err := emb.Embed(c.Content)
+		vec, err := emb.Embed(p.content)
 		if err != nil {
 			res.Skipped++
-			continue // never abort the mine on an embed failure
+			continue
 		}
-		if err := db.InsertEmbedding(d, id, embed.EncodeVector(vec)); err != nil {
+		if err := db.InsertEmbedding(d, p.id, embed.EncodeVector(vec)); err != nil {
 			res.Skipped++
 		} else {
 			res.Embedded++

--- a/internal/mine/mine_test.go
+++ b/internal/mine/mine_test.go
@@ -1,6 +1,7 @@
 package mine
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -28,7 +29,7 @@ func TestRunInsertsChunksAndEmbeds(t *testing.T) {
 	jsonl := `{"type":"user","sessionId":"s1","timestamp":"2026-06-25T10:00:00Z","message":{"role":"user","content":"This is a long enough question about database design choices."}}`
 	jp := writeJSONL(t, jsonl)
 	dbp := filepath.Join(t.TempDir(), "sessions.db")
-	res, err := Run(dbp, jp, fakeEmbedder{avail: true})
+	res, err := Run(context.Background(), dbp, jp, fakeEmbedder{avail: true})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -41,10 +42,10 @@ func TestRunIdempotent(t *testing.T) {
 	jsonl := `{"type":"user","sessionId":"s1","timestamp":"2026-06-25T10:00:00Z","message":{"role":"user","content":"This is a long enough question about database design choices."}}`
 	jp := writeJSONL(t, jsonl)
 	dbp := filepath.Join(t.TempDir(), "sessions.db")
-	if _, err := Run(dbp, jp, fakeEmbedder{avail: false}); err != nil {
+	if _, err := Run(context.Background(), dbp, jp, fakeEmbedder{avail: false}); err != nil {
 		t.Fatal(err)
 	}
-	res, err := Run(dbp, jp, fakeEmbedder{avail: false})
+	res, err := Run(context.Background(), dbp, jp, fakeEmbedder{avail: false})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +63,7 @@ func TestRunSkippedOnEmbedError(t *testing.T) {
 	jsonl := `{"type":"user","sessionId":"s1","timestamp":"2026-06-25T10:00:00Z","message":{"role":"user","content":"This is a long enough question about database design choices."}}`
 	jp := writeJSONL(t, jsonl)
 	dbp := filepath.Join(t.TempDir(), "sessions.db")
-	res, err := Run(dbp, jp, errEmbedder{})
+	res, err := Run(context.Background(), dbp, jp, errEmbedder{})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -75,11 +76,29 @@ func TestRunSkipsEmbeddingsWhenUnavailable(t *testing.T) {
 	jsonl := `{"type":"user","sessionId":"s1","timestamp":"2026-06-25T10:00:00Z","message":{"role":"user","content":"This is a long enough question about database design choices."}}`
 	jp := writeJSONL(t, jsonl)
 	dbp := filepath.Join(t.TempDir(), "sessions.db")
-	res, err := Run(dbp, jp, fakeEmbedder{avail: false})
+	res, err := Run(context.Background(), dbp, jp, fakeEmbedder{avail: false})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if res.ChunksInserted != 1 || res.Embedded != 0 {
 		t.Fatalf("result = %+v, want 1 inserted / 0 embedded", res)
+	}
+}
+
+// TestRunDefersEmbeddingWhenContextDone verifies that when the deadline has
+// passed, chunks are still stored but embedding is deferred (left pending for
+// the `embed` subcommand to backfill). This guards the 60s Stop-hook budget.
+func TestRunDefersEmbeddingWhenContextDone(t *testing.T) {
+	jsonl := `{"type":"user","sessionId":"s1","timestamp":"2026-06-25T10:00:00Z","message":{"role":"user","content":"This is a long enough question about database design choices."}}`
+	jp := writeJSONL(t, jsonl)
+	dbp := filepath.Join(t.TempDir(), "sessions.db")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // deadline already reached
+	res, err := Run(ctx, dbp, jp, fakeEmbedder{avail: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.ChunksInserted != 1 || res.Embedded != 0 || res.Deferred != 1 {
+		t.Fatalf("result = %+v, want 1 inserted / 0 embedded / 1 deferred", res)
 	}
 }

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math"
+	"os"
 	"sort"
 	"strings"
 
@@ -141,10 +142,12 @@ type Stats struct {
 	Pending  int
 	Oldest   string
 	Newest   string
+	DBSize   string // human-readable on-disk size, e.g. "4.2 MB"
 }
 
-// GetStats reports index counts and date range.
-func GetStats(d *sql.DB) (Stats, error) {
+// GetStats reports index counts, date range, and on-disk DB size. dbPath is
+// the file path used to measure size (SQLite has no portable SQL for it).
+func GetStats(d *sql.DB, dbPath string) (Stats, error) {
 	var s Stats
 	q := func(query string, dest any) error { return d.QueryRow(query).Scan(dest) }
 	if err := q(`SELECT COUNT(DISTINCT session_id) FROM chunks`, &s.Sessions); err != nil {
@@ -166,5 +169,22 @@ func GetStats(d *sql.DB) (Stats, error) {
 	if newest.Valid {
 		s.Newest = newest.String
 	}
+	// On-disk size is best-effort; a missing/unstatable file leaves it blank.
+	if fi, err := os.Stat(dbPath); err == nil {
+		s.DBSize = humanBytes(fi.Size())
+	}
 	return s, nil
+}
+
+// humanBytes formats a byte count as a short human-readable size.
+func humanBytes(n int64) string {
+	const unit = 1024.0
+	f := float64(n)
+	units := []string{"B", "KB", "MB", "GB", "TB"}
+	i := 0
+	for f >= unit && i < len(units)-1 {
+		f /= unit
+		i++
+	}
+	return fmt.Sprintf("%.1f %s", f, units[i])
 }

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -14,14 +14,23 @@ import (
 )
 
 // Search returns up to limit ranked results. usedEmbeddings is false when
-// the FTS5 fallback was used.
+// the FTS5 fallback was used. Fallback also triggers when Ollama is up but the
+// store has no embeddings yet (e.g. mined while Ollama was down, now back) —
+// cosine would return nothing, so we don't go blind.
 func Search(d *sql.DB, emb embed.Embedder, query string, limit int) ([]internal.SearchResult, bool, error) {
-	if emb.Available() {
+	if emb.Available() && hasEmbeddings(d) {
 		res, err := cosineSearch(d, emb, query, limit)
 		return res, true, err
 	}
 	res, err := ftsSearch(d, query, limit)
 	return res, false, err
+}
+
+// hasEmbeddings reports whether at least one embedding row exists.
+func hasEmbeddings(d *sql.DB) bool {
+	var ok int
+	err := d.QueryRow(`SELECT EXISTS(SELECT 1 FROM embeddings)`).Scan(&ok)
+	return err == nil && ok == 1
 }
 
 func cosineSearch(d *sql.DB, emb embed.Embedder, query string, limit int) ([]internal.SearchResult, error) {
@@ -69,7 +78,10 @@ func cosineSearch(d *sql.DB, emb embed.Embedder, query string, limit int) ([]int
 }
 
 func ftsSearch(d *sql.DB, query string, limit int) ([]internal.SearchResult, error) {
-	match := `"` + strings.ReplaceAll(query, `"`, `""`) + `"`
+	match := ftsMatchExpr(query)
+	if match == "" {
+		return nil, nil // no usable terms; caller prints "(no results)"
+	}
 	rows, err := d.Query(
 		`SELECT c.session_date, c.role, c.content, bm25(chunks_fts) AS rank
 		 FROM chunks c JOIN chunks_fts ON c.id = chunks_fts.rowid
@@ -90,6 +102,19 @@ func ftsSearch(d *sql.DB, query string, limit int) ([]internal.SearchResult, err
 		out = append(out, r)
 	}
 	return out, rows.Err()
+}
+
+// ftsMatchExpr builds an OR of quoted terms from the query for keyword recall.
+// The fallback exists for the "I half-remember the idea, not the words" case,
+// so a phrase match (requiring adjacency) is too strict: splitting on
+// whitespace and OR-ing the terms matches any. Each term is FTS-quoted with
+// internal double quotes doubled. Returns "" when there are no usable terms.
+func ftsMatchExpr(query string) string {
+	var terms []string
+	for _, w := range strings.Fields(query) {
+		terms = append(terms, `"`+strings.ReplaceAll(w, `"`, `""`)+`"`)
+	}
+	return strings.Join(terms, " OR ")
 }
 
 func cosine(a, b []float32) float64 {

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -138,11 +138,14 @@ func TestGetStats(t *testing.T) {
 	dbp := seed(t, stubEmbedder{avail: true})
 	d, _ := db.Open(dbp)
 	defer d.Close()
-	st, err := GetStats(d)
+	st, err := GetStats(d, dbp)
 	if err != nil {
 		t.Fatalf("GetStats: %v", err)
 	}
 	if st.Chunks != 2 || st.Embedded != 2 || st.Pending != 0 {
 		t.Fatalf("stats = %+v", st)
+	}
+	if st.DBSize == "" {
+		t.Fatal("DBSize empty, want a human-readable size from os.Stat")
 	}
 }

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -81,6 +81,59 @@ func TestSearchFTSFallback(t *testing.T) {
 	}
 }
 
+// TestSearchFallsBackToFTSWhenNoEmbeddings: Ollama is up but the DB has zero
+// embedding rows (e.g. mined while Ollama was down, now back). Cosine would
+// return nothing; search must fall back to FTS rather than go blind.
+func TestSearchFallsBackToFTSWhenNoEmbeddings(t *testing.T) {
+	dbp := filepath.Join(t.TempDir(), "sessions.db")
+	d, err := db.Open(dbp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	c := internal.Chunk{SessionID: "s1", SessionDate: "2026-06-25", Role: "user",
+		MessageIndex: 0, ChunkIndex: 0, Content: "json schema config validation approach", CreatedAt: "2026-06-25T10:00:00Z"}
+	if _, _, err := db.InsertChunk(d, c); err != nil {
+		t.Fatal(err)
+	}
+	emb := stubEmbedder{avail: true}
+	res, used, err := Search(d, emb, "validation", 5)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if used {
+		t.Fatal("usedEmbeddings = true, want false (no embeddings -> FTS fallback)")
+	}
+	if len(res) == 0 {
+		t.Fatal("expected FTS results when embeddings table empty")
+	}
+}
+
+// TestSearchFTSMatchesNonAdjacentTerms: the FTS fallback must OR the terms so
+// a query like "config validation" matches a chunk where the words are not
+// adjacent (a phrase match would miss it).
+func TestSearchFTSMatchesNonAdjacentTerms(t *testing.T) {
+	dbp := filepath.Join(t.TempDir(), "sessions.db")
+	d, err := db.Open(dbp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	c := internal.Chunk{SessionID: "s1", SessionDate: "2026-06-25", Role: "user",
+		MessageIndex: 0, ChunkIndex: 0, Content: "the validation step checks the input config separately", CreatedAt: "2026-06-25T10:00:00Z"}
+	if _, _, err := db.InsertChunk(d, c); err != nil {
+		t.Fatal(err)
+	}
+	emb := stubEmbedder{avail: false}
+	res, _, err := Search(d, emb, "config validation", 5)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) == 0 {
+		t.Fatal("phrase match failed; OR match should find non-adjacent terms")
+	}
+}
+
 func TestGetStats(t *testing.T) {
 	dbp := seed(t, stubEmbedder{avail: true})
 	d, _ := db.Open(dbp)


### PR DESCRIPTION
Addresses the four post-merge recommendations from the final whole-branch
review of #1.

## Changes

- **mine: wall-clock deadline (Important #3).** `Run` now takes
  `context.Context` and splits storing (phase 1, fast) from embedding
  (phase 2). When the ctx deadline hits, chunks are still stored but
  embedding is deferred (new `Result.Deferred`). The `mine` subcommand
  uses a 50s deadline — headroom under the 60s Stop-hook budget — and
  reports deferred chunks with a backfill hint. Guards against a slow
  Ollama blowing the hook budget.

- **search: FTS fallback when no embeddings (Important #4).** `Search`
  now falls back to FTS5 when Ollama is up but the store has zero
  embedding rows (the mine-while-Ollama-down then Ollama-returns case).
  Previously cosine returned nothing and search went blind.

- **search: per-term OR FTS recall (Important #5).** `ftsSearch` builds
  an OR of quoted terms instead of one phrase, so `"config validation"`
  matches chunks where the words are non-adjacent — the whole point of
  the keyword fallback.

- **search: DB size in stats (Minor, UC-6).** `GetStats` reports
  on-disk size; `stats` prints `DB size: 2.1 MB` per use-cases.md UC-6.

## Tests

- `TestRunDefersEmbeddingWhenContextDone` — deadline defers embedding
- `TestSearchFallsBackToFTSWhenNoEmbeddings` — empty-embeddings fallback
- `TestSearchFTSMatchesNonAdjacentTerms` — OR recall vs phrase match
- `TestGetStats` extended — DBSize non-empty

`go test -race ./...` green (28 tests), `go vet` clean, `gofmt -l` empty,
`CGO_ENABLED=0` build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)