### PR TITLE
docs: sync CLAUDE.md with post-merge behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ internal/db/
   db.go                           — open, WAL, busy_timeout, schema version check
   schema.sql                      — embedded via go:embed
 internal/mine/
-  mine.go                         — orchestrate: parse → chunk → store → embed (two-phase: store first, embed respects ctx deadline; deferred chunks backfilled via `embed`)
+  mine.go                         — orchestrate: parse → chunk → store → embed (two-phase: store first, embed respects ctx deadline; deferred chunks backfilled via `embed`). Defines `mine.Result` (ChunksInserted / Embedded / Skipped / Deferred).
   parse.go                        — JSONL → []Message
   chunk.go                        — []Message → []Chunk (split, filter, truncate; rune-safe hard-split for Cyrillic)
 internal/embed/
@@ -84,7 +84,7 @@ Primary: embed query → exhaustive cosine over all `embeddings` rows loaded int
 
 - **Pure Go, no CGO.** `go build` must produce a portable static binary.
 - **Go 1.26+.** Use `go 1.26` in `go.mod`.
-- **60-second budget.** `mine` runs inside a Claude Code Stop hook. Must complete well within 60s.
+- **60-second budget.** `mine` runs inside a Claude Code Stop hook. Must complete well within 60s (enforced internally via a 50s `context.Context` deadline — see Embeddings).
 - **Mixed Ukrainian + English content.** `bge-m3` handles both; `unicode61 remove_diacritics 0` tokenizer for FTS5.
 - **Per-project isolation.** No cross-project search, no shared state.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,20 +37,21 @@ Single Go binary, no daemon, no shared state between projects. Four subcommands 
 session-indexer mine   <jsonl-path> --db <path>        # parse JSONL → SQLite
 session-indexer search <query>      --db <path> [--limit N] [--json]
 session-indexer embed               --db <path>        # backfill missing embeddings
-session-indexer stats               --db <path>
+session-indexer stats               --db <path>        # sessions, chunks, pending, DB size
 ```
 
 ### File Layout
 
 ```
 cmd/session-indexer/main.go       — Cobra root + subcommands
+internal/types.go                 — shared row types: Chunk, SearchResult
 internal/db/
   db.go                           — open, WAL, busy_timeout, schema version check
   schema.sql                      — embedded via go:embed
 internal/mine/
-  mine.go                         — orchestrate: parse → chunk → store → embed
+  mine.go                         — orchestrate: parse → chunk → store → embed (two-phase: store first, embed respects ctx deadline; deferred chunks backfilled via `embed`)
   parse.go                        — JSONL → []Message
-  chunk.go                        — []Message → []Chunk (split, filter, truncate)
+  chunk.go                        — []Message → []Chunk (split, filter, truncate; rune-safe hard-split for Cyrillic)
 internal/embed/
   embed.go                        — Ollama client, probe+model-check, float32 BLOB
 internal/search/
@@ -73,9 +74,11 @@ Extract `user` and `assistant` turns where `isMeta=false`. Skip XML/HTML (`<`), 
 
 Ollama REST: `POST localhost:11434/api/embed`, model `bge-m3:latest` (1024 dims). Probe first with `GET /api/tags` (2s timeout) — if unavailable, skip embeddings and log a warning. Store as `encoding/binary` LittleEndian float32 BLOB.
 
+`mine` runs with a 50s `context.Context` deadline (headroom under the 60s Stop-hook budget). Storing is fast and unconditional; embedding is the phase that respects the deadline. Chunks past the deadline are stored but flagged `Deferred` in the `Result` and left without an embedding row — backfill with `session-indexer embed`. Embed errors never abort the mine (counted as `Skipped`).
+
 ### Search
 
-Primary: embed query → exhaustive cosine over all `embeddings` rows loaded into memory. Scale assumption: <10k chunks. Fallback when Ollama unavailable: FTS5 BM25, with output note indicating lower quality.
+Primary: embed query → exhaustive cosine over all `embeddings` rows loaded into memory. Scale assumption: <10k chunks. Fallback to FTS5 BM25 when Ollama is unavailable **OR** the store has zero embeddings (e.g. mined while Ollama was down); FTS uses per-term OR recall, not phrase match. Output notes when the fallback is used.
 
 ## Key Constraints
 
@@ -87,4 +90,6 @@ Primary: embed query → exhaustive cosine over all `embeddings` rows loaded int
 
 ## Stop Hook Integration
 
-`.claude/hooks/session-end.sh` calls `session-indexer mine <transcript_path> --db <project-root>/.claude/sessions.db` on every session end. The hook fires with JSON on stdin containing `transcript_path` and `session_id`. JSONL files may be deleted by Claude Code cleanup shortly after — mine at hook time.
+`.claude/settings.local.json` wires two Stop-hook commands into a single `Stop` entry: `bash .claude/hooks/session-end.sh` (writes `session-log.md`) and `bash .claude/hooks/session-index.sh` (runs `session-indexer mine <transcript_path> --db <project-root>/.claude/sessions.db`). The hook fires with JSON on stdin containing `transcript_path` and `session_id`. JSONL files may be deleted by Claude Code cleanup shortly after — mine at hook time. The `session-index.sh` guard silently no-ops until `session-indexer` is on `PATH`.
+
+> Note: in Claude Code 2.1.x, multiple **top-level** `Stop` array entries are not all fired — only the first runs. Put multiple Stop commands in the **same** entry's `hooks` array (the structure used here).


### PR DESCRIPTION
Pure doc-sync — no code changes. Brings CLAUDE.md in line with the four
post-merge improvements from PR #2 plus the bug lessons from the Stop-hook
post-mortem.

Changes:
- **File layout**: add `internal/types.go` (Chunk, SearchResult)
- **`mine.go`**: note the two-phase store/embed with ctx deadline, deferred
  backfill semantics, rune-safe hard-split for Cyrillic
- **`stats` line**: contracts what it reports (sessions, chunks, pending, DB size)
- **Embeddings**: 50s deadline, `Deferred` vs `Skipped` semantics,
  "embed errors never abort the mine"
- **Search**: FTS fallback also triggers when the embeddings table is empty;
  per-term OR recall (not phrase match)
- **Stop Hook Integration**: names both hooks in `settings.local.json` and
  documents the Claude Code 2.1.x multi-top-level-Stop quirk that nearly
  lost days of sessions — the single-entry workaround is the structure
  this repo uses

🤖 Generated with [Claude Code](https://claude.com/claude-code)