### PR TITLE
docs: sync design docs (architecture/requirements/use-cases) + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ internal/search/
 
 SQLite at `<project-root>/.claude/sessions.db` (gitignored, per-project). No CGO — use `modernc.org/sqlite`. Open with WAL + `synchronous=NORMAL` + `busy_timeout=5000`.
 
-Schema version stored in `meta` table (`key='schema_version'`). On open: if version mismatches, exit with "run: session-indexer reindex". Never silently evolve schema.
+Schema version stored in `meta` table (`key='schema_version'`). On open: if version mismatches, exit with "schema version mismatch (X != Y): delete <db-path> and re-mine to rebuild". There is no `reindex` subcommand; users recover by deleting the DB and re-mining available JSONLs. Never silently evolve schema.
 
 Dedup key: `UNIQUE(session_id, message_index, chunk_index)` — `INSERT OR IGNORE` makes `mine` idempotent.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,10 +43,15 @@ Claude Code JSONL
               ▼
 ┌─────────────────────┐
 │  search cmd         │
-│  1. FTS5 → top-50   │
-│  2. load embeddings  │
-│  3. cosine re-rank   │
+│  1. embed(query)     │
+│  2. cosine over all  │
+│     embeddings rows  │
+│  3. JOIN chunks      │
 │  4. print results    │
+│  (fallback: FTS5     │
+│   BM25 if Ollama     │
+│   down OR no         │
+│   embeddings yet)    │
 └─────────────────────┘
 ```
 
@@ -111,9 +116,12 @@ Schema version check on every open:
 var v string
 db.QueryRow(`SELECT value FROM meta WHERE key='schema_version'`).Scan(&v)
 if v != SchemaVersion {
-    return fmt.Errorf("schema version mismatch (%s != %s): run session-indexer reindex", v, SchemaVersion)
+    return fmt.Errorf("schema version mismatch (%s != %s): delete %s and re-mine to rebuild", v, SchemaVersion, path)
 }
 ```
+There is no `reindex` subcommand — schema bumps are not auto-evolved; users
+recover by deleting the DB and re-mining available JSONLs (mine is
+idempotent via `INSERT OR IGNORE`).
 
 ---
 
@@ -197,14 +205,24 @@ query string
          JOIN chunks ON id to fetch content + metadata
          → results
 
-Fallback (Ollama unavailable):
+Fallback (Ollama unavailable OR embeddings table is empty):
     FTS5 BM25:
-    SELECT chunks.id, content, session_date, role
-    FROM chunks JOIN chunks_fts ON chunks.id = chunks_fts.rowid
-    WHERE chunks_fts MATCH fts5_escape(query)
-    ORDER BY bm25(chunks_fts) LIMIT --limit
+    SELECT c.session_date, c.role, c.content, bm25(chunks_fts) AS rank
+    FROM chunks c JOIN chunks_fts ON c.id = chunks_fts.rowid
+    WHERE chunks_fts MATCH <per-term OR match>
+    ORDER BY rank LIMIT --limit
     print note: "(embedding unavailable — FTS5 keyword results only)"
-```
+
+The FTS5 query is built by splitting the user query on whitespace and
+OR-ing the terms as individually quoted FTS5 phrases (e.g. `"config"
+OR "validation"`), not wrapping the whole query in one phrase. This is
+better recall at the cost of precision — the fallback exists for
+"vaguely remember the idea, not the exact words", which is the same
+semantic-search need the cosine path solves.
+
+The fallback also triggers when Ollama is up but the store has zero
+embeddings (e.g. mined while Ollama was down, now back). Without this,
+cosine would return nothing and search would go blind.
 
 **Scale assumption:** personal session recall, <10k chunks (~40MB vectors in-memory).
 Revisit if index exceeds 50k chunks.
@@ -270,19 +288,35 @@ The Stop hook receives JSON on stdin. Relevant fields:
 }
 ```
 
-`session-end.sh` calls session-indexer after writing the summary:
+Two hooks run on every session stop, both wired inside a single `Stop` entry
+of `settings.local.json` (see warning below):
+
+- `bash .claude/hooks/session-end.sh` — writes `session-log.md` via an LLM
+  call (agy → opencode → raw transcript fallback). Includes a 2h "skill
+  already ran" mtime-skip to avoid double-work.
+- `bash .claude/hooks/session-index.sh` — runs `session-indexer mine` on the
+  transcript and silently no-ops until `session-indexer` is on PATH.
+
+`session-index.sh` (simplified):
 
 ```bash
-HOOK_INPUT=$(cat)
-SESSION_JSONL=$(echo "$HOOK_INPUT" | jq -r '.transcript_path')
+INPUT=$(cat)
+TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path')
+[[ -z "$TRANSCRIPT" || ! -f "$TRANSCRIPT" ]] && exit 0
+command -v session-indexer >/dev/null 2>&1 || exit 0
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
-
-if [[ -n "$SESSION_JSONL" && "$SESSION_JSONL" != "null" && -f "$SESSION_JSONL" \
-      && -x "$(command -v session-indexer)" ]]; then
-    session-indexer mine "$SESSION_JSONL" \
-        --db "$PROJECT_ROOT/.claude/sessions.db"
-fi
+session-indexer mine "$TRANSCRIPT" --db "$PROJECT_ROOT/.claude/sessions.db"
 ```
+
+Hook logs go to `~/.cache/<project-name>/hooks.log` (per-project, derived
+from the repo name by `hook-common.sh`).
+
+> **Warning — Claude Code 2.1.x multi-Stop-hook quirk:** when `hooks.Stop`
+> is an array of multiple top-level entries, only the **first** entry's
+> commands run. Put multiple Stop commands in the **same** entry's
+> `hooks` array (the structure used here). Verified empirically:
+> 2026-06-25 to 2026-06-28, sessions went unmined until the settings
+> file was collapsed to a single entry.
 
 Note: `--project` flag removed (redundant — DB path is per-project).
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -83,8 +83,9 @@ ChromaDB/HNSW for this reason). A corrupted or deleted DB can be rebuilt by
 re-mining available JSONLs.
 
 Schema versioned via `meta` table (`schema_version`). On open, if version
-mismatches binary expectation: print error + "run: session-indexer reindex"
-and exit. No silent schema evolution.
+mismatches binary expectation: print wrapped error naming both versions and
+instructing the user to delete the DB and re-mine available JSONLs (mine is
+idempotent). No silent schema evolution. There is no `reindex` subcommand.
 
 ### NFR-3: Pure Go build
 
@@ -93,8 +94,8 @@ library dependencies. `go build` produces a portable binary.
 
 ### NFR-4: Performance
 
-- `mine`: index one session in <30s on CPU (embedding 100 chunks via Ollama); must complete within 60s Stop hook timeout
-- `search`: return results in <2s (FTS5 fallback), <5s (embedding cosine path)
+- `mine`: index one session in <30s on CPU (embedding 100 chunks via Ollama); must complete within 60s Stop hook timeout. Enforced internally via a 50s `context.Context` deadline. The mine run is split into two phases: (1) storing every chunk (fast, idempotent), then (2) embedding new chunks under the deadline. Chunks past the deadline are stored but flagged `Deferred` in `mine.Result` and left without an embedding row — backfill with `session-indexer embed`. Embed errors never abort a mine (counted as `Skipped`).
+- `search`: return results in <2s (FTS5 fallback), <5s (embedding cosine path). The fallback is per-term OR recall (not phrase match) and also triggers when the store has zero embeddings.
 
 ### NFR-5: Language support
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -43,13 +43,14 @@ alternative weeks ago but can't remember the exact wording.
 **Trigger:** Val closes Claude Code (or runs `/exit`).
 
 **Flow:**
-1. Stop hook fires: `bash .claude/hooks/session-end.sh`
-2. Hook reads `transcript_path` from stdin JSON.
-3. Hook writes summary, then calls `session-indexer mine <transcript_path> --db .claude/sessions.db`
-4. Binary opens/creates DB (schema version check), parses JSONL, filters noise, chunks messages (user/assistant/tool).
-5. Inserts chunks into `chunks` + `chunks_fts`. Dedup by `(session_id, message_index, chunk_index)`.
-6. For each chunk: calls Ollama `bge-m3` to generate embedding, stores in `embeddings`.
-7. Exits in <30s (well within 60s hook timeout).
+1. Stop hook fires: both `bash .claude/hooks/session-end.sh` and `bash .claude/hooks/session-index.sh` (wired into a single `Stop` entry of `settings.local.json` — Claude Code 2.1.x runs only the first top-level entry, so both must live in the same entry's `hooks` array).
+2. Each hook reads `transcript_path` from stdin JSON.
+3. `session-end.sh` writes summary to `session-log.md` (LLM call via agy → opencode → raw transcript fallback).
+4. `session-index.sh` calls `session-indexer mine <transcript_path> --db <project-root>/.claude/sessions.db` (silently no-ops until the binary is on PATH).
+5. Binary opens/creates DB (schema version check), parses JSONL, filters noise, chunks messages (user/assistant/tool).
+6. Inserts chunks into `chunks` + `chunks_fts`. Dedup by `(session_id, message_index, chunk_index)`.
+7. For each chunk: calls Ollama `bge-m3` to generate embedding, stores in `embeddings`. Chunks past the 50s `context.Context` deadline are stored but flagged `Deferred` (no embedding row yet); backfill with `session-indexer embed` once Ollama is reachable. Embed errors never abort the mine (counted as `Skipped`).
+8. Exits in <30s in the happy path (well within 60s hook timeout); can use up to 50s before deferring.
 
 **Success:** Session indexed before JSONL is cleaned up by Claude Code.
 


### PR DESCRIPTION
Final doc-sync after PR #2's behavior changes. Brings the design docs
back in line with the implementation so a new agent reading the docs
gets an accurate picture.

**architecture.md:**
- Schema-version error message: now matches the actual code output
  ("delete <db-path> and re-mine to rebuild") and explicitly notes
  there is no reindex subcommand
- Stop Hook section: now describes both hooks (session-end.sh and
  session-index.sh), the single-Stop-entry workaround for the
  Claude Code 2.1.x multi-Stop quirk, the per-project log dir, and
  the session-index.sh guard against a missing binary
- Search Algorithm: FTS fallback also triggers when embeddings table
  is empty; query is per-term OR (not phrase)
- Component Diagram: search cmd flow is now embedding-first (cosine
  over all embeddings rows) — was FTS-first + cosine re-rank, the
  pre-PR#2 design

**requirements.md:**
- NFR-4 mine: documents 50s ctx deadline, two-phase store/embed,
  Deferred vs Skipped semantics, embed backfill path
- NFR-4 search: notes per-term OR FTS and empty-embeddings trigger
- NFR-2 schema-version: matches the new error message

**use-cases.md UC-3:**
- Names both hooks, not just session-end.sh
- Documents 50s deadline / Deferred / Skipped behavior on mine
- Reflects 30s happy path / 50s deadline split

**CLAUDE.md:**
- Schema-version error message: matches the new code output
- Notes absence of a reindex subcommand

**Not touched:** `docs/review-consilium.md` is a design-history record
capturing what was decided at what point. Updating its resolved-status
lines would falsify the historical record; new agents reading it
should see the original resolution as it happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)