### PR TITLE
chore: gitignore docs/superpowers/ (SDD plan scratch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ vendor/
 
 # Skills telemetry
 .claude/skills/fix-review/telemetry.jsonl
+
+# SDD scratch — implementation plans written by writing-plans skill
+docs/superpowers/


### PR DESCRIPTION
The writing-plans skill drops plan files into `docs/superpowers/plans/`
as workflow scratch. They aren't project docs — they're inputs to the
SDD workflow, analogous to `.superpowers/sdd/`.

Without this entry, every `git status` shows the plan as untracked,
and a careless `git add .` would commit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)