### PR TITLE
docs: product review fixes + session-recall integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ vendor/
 
 # SDD scratch — implementation plans written by writing-plans skill
 docs/superpowers/
+
+tmp/

--- a/README.md
+++ b/README.md
@@ -1,52 +1,167 @@
 # session-indexer
 
-Per-project semantic search over Claude Code session history. Pure Go, no CGO,
-no daemon. Indexes JSONL transcripts into a per-project SQLite store and
-retrieves them via bge-m3 embeddings (Ollama) with FTS5 BM25 fallback.
+Per-project semantic search over Claude Code session history. Indexes JSONL
+transcripts into a per-project SQLite store; retrieves via bge-m3 embeddings
+(Ollama) with FTS5 BM25 fallback. Automatically injects relevant past context
+at session start.
+
+**Problem it solves:** returning to a project after a week and needing to find
+"what did we decide about X" across dozens of past sessions. `session-end`
+gives you "where I left off last time"; `session-indexer` gives you "what we
+discussed across all history" — by semantic similarity, not grep.
+
+**Why not mempalace?** Mempalace uses a centralised mutable store shared across
+all projects. A single corruption wipes history for every project. `session-indexer`
+is append-only and per-project (`.claude/sessions.db`) — the worst that can
+happen is losing one project's DB, which is fully recoverable by re-mining the
+available JSONLs (`mine` is idempotent).
+
+## Prerequisites
+
+- **Go 1.26+** — to build the binary
+- **Ollama** — for vector embeddings (optional but recommended)
+  - `ollama pull bge-m3:latest` — 1024-dim multilingual model (EN + UA)
+- **jq** — used by the SessionStart hook to parse search results
+- **python3** — used by the `/recall` skill and `session-recall.sh` for output formatting
+
+## Quick Start
+
+```bash
+# 1. Build and install the binary
+go install ./cmd/session-indexer
+
+# 2. (Optional) Pull the embedding model
+ollama pull bge-m3:latest
+
+# 3. Wire the hooks into your project (one-time setup)
+#    Copy session-index.sh + session-recall.sh → .claude/hooks/
+#    Update .claude/settings.local.json with Stop + SessionStart entries
+#    Install /recall skill → .claude/skills/session-recall/SKILL.md
+#    See "Hook Setup" below for the exact steps.
+
+# 4. End a Claude Code session — Stop hook mines it into .claude/sessions.db
+#    (The hook silently no-ops until session-indexer is in PATH)
+
+# 5. Open a new session — SessionStart hook injects relevant past context
+#    automatically based on current git branch + recent commits
+
+# 6. Search manually at any time
+session-indexer search "config validation approach" --db .claude/sessions.db
+# or from inside Claude Code:
+# /recall config validation approach
+```
 
 ## Build
 
 ```bash
 go build -o bin/session-indexer ./cmd/session-indexer
-go install ./cmd/session-indexer   # to PATH
+go install ./cmd/session-indexer   # to PATH (activates the Stop hook guard)
 ```
 
 ## Usage
 
 ```bash
 session-indexer mine   <jsonl-path> --db .claude/sessions.db
-session-indexer search "config validation approach" --db .claude/sessions.db [--limit N] [--json]
-session-indexer embed  --db .claude/sessions.db     # backfill missing embeddings
-session-indexer stats  --db .claude/sessions.db
+session-indexer search <query>      --db .claude/sessions.db [--limit N] [--json]
+session-indexer embed               --db .claude/sessions.db
+session-indexer stats               --db .claude/sessions.db
 ```
+
+### `mine` output
+
+```
+mined: 23 chunks inserted, 21 embedded, 0 skipped, 2 deferred
+```
+
+- **inserted** — new chunks stored (duplicates skipped via INSERT OR IGNORE)
+- **embedded** — chunks that got a vector embedding from Ollama
+- **skipped** — embed errors (Ollama returned an error); stored in DB, no embedding, backfill via `embed`
+- **deferred** — embed deadline hit (50s ctx timeout); stored in DB, no embedding, same backfill path
+
+### `search --json` output schema
+
+```json
+[
+  {
+    "SessionDate": "2026-06-10",
+    "Role":        "user",
+    "Content":     "We decided to use a ring buffer for the event queue…",
+    "Score":       0.847
+  }
+]
+```
+
+`Score` is cosine similarity (0–1) in embedding mode, or negated BM25 rank in
+FTS5 fallback mode (higher is always better in both cases).
 
 ## Embeddings
 
-Optional. Requires Ollama on `localhost:11434` with `bge-m3:latest`
-(`ollama pull bge-m3:latest`). `mine` runs with a 50s `context.Context`
-deadline (headroom under the 60s Stop-hook budget): storing is fast and
-unconditional, embedding is the phase that respects the deadline. Chunks
-past the deadline are stored but flagged as **deferred** — no embedding
-row yet, backfill with `session-indexer embed` once Ollama is reachable.
-Embed errors never abort a mine — such chunks are stored and counted as
-**Skipped** (same storage state as Deferred: present in the DB, no
-embedding row, included in `stats --db` `pending`). Deferred and Skipped
-differ only in cause (deadline vs error), not in backfill path.
+Requires Ollama on `localhost:11434` with `bge-m3:latest`. `mine` runs with a
+50s `context.Context` deadline (headroom under the 60s Stop-hook budget):
+storing is fast and unconditional; embedding respects the deadline. Chunks past
+the deadline are stored but `Deferred` (no embedding row); backfill with
+`session-indexer embed`. Embed errors count as `Skipped` — same storage state,
+same backfill path, different cause.
 
-When Ollama is unavailable or the store has zero embeddings, `search`
-falls back to FTS5 BM25 with per-term OR recall (not phrase match) and
-prints an output note indicating the lower quality.
+When Ollama is unavailable or the store has zero embeddings, `search` falls back
+to FTS5 BM25 with per-term OR recall and notes this in the output.
 
-## Automatic indexing
+## Hook Setup
 
-A Stop hook fires on every session end. It runs two commands inside one
-`Stop` entry of `settings.local.json`: `bash .claude/hooks/session-end.sh`
-(writes `session-log.md`) and `bash .claude/hooks/session-index.sh`
-(runs `session-indexer mine <transcript> --db .claude/sessions.db`).
+Two Stop hooks run on every session end (wired in a single `Stop` entry of
+`settings.local.json` — Claude Code 2.1.x runs only the first top-level entry):
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash .claude/hooks/session-end.sh",   "timeout": 60 },
+          { "type": "command", "command": "bash .claude/hooks/session-index.sh", "timeout": 60 }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash .claude/hooks/session-last.sh",   "timeout": 10 },
+          { "type": "command", "command": "bash .claude/hooks/session-recall.sh", "timeout": 15 }
+        ]
+      }
+    ]
+  }
+}
+```
+
 `session-index.sh` silently no-ops until `session-indexer` is on PATH.
-
-> Note: in Claude Code 2.1.x, only the first top-level `Stop` entry's
-> commands run. Put multiple Stop commands in the **same** entry's
-> `hooks` array (the structure used here).
+`session-recall.sh` no-ops until `.claude/sessions.db` exists (after the first indexed session).
 
 Hook logs go to `~/.cache/<project-name>/hooks.log`.
+
+## Troubleshooting
+
+**Hooks not running:**
+Check that both commands are in the same `Stop` entry's `hooks` array (not two
+separate top-level `Stop` entries). See Hook Setup above.
+
+**Schema version mismatch:**
+```
+schema version mismatch (X != Y): delete .claude/sessions.db and re-mine to rebuild
+```
+Delete the DB and re-run `mine` on your JSONLs — `mine` is idempotent.
+
+**Search returns poor results / FTS5 fallback:**
+```bash
+session-indexer stats --db .claude/sessions.db   # check pending count
+session-indexer embed --db .claude/sessions.db   # backfill embeddings
+```
+
+**Read hook logs:**
+```bash
+tail -40 ~/.cache/$(basename "$(git rev-parse --show-toplevel)")/hooks.log
+```
+
+**DB size:** scale assumption is <10k chunks (~40MB vectors in memory). No hard
+limit, but `search` loads all embedding rows into memory for cosine; if the DB
+grows beyond ~50k chunks, revisit.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ available JSONLs (`mine` is idempotent).
 - **Go 1.26+** — to build the binary
 - **Ollama** — for vector embeddings (optional but recommended)
   - `ollama pull bge-m3:latest` — 1024-dim multilingual model (EN + UA)
-- **jq** — used by the SessionStart hook to parse search results
+- **jq** — used by the SessionStart hook to format the hook output JSON
 - **python3** — used by the `/recall` skill and `session-recall.sh` for output formatting
 
 ## Quick Start

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -334,7 +334,8 @@ relevant past session chunks as `additionalContext`.
 SESSION_START hooks:
   1. session-last.sh   — injects last session-log.md entry (structured summary)
   2. session-recall.sh — derives a query from git branch + last 3 commit messages,
-                         runs `session-indexer search --json`, filters tool-call noise,
+                         runs `session-indexer search "$QUERY" --db "$DB" --limit 5 --json`,
+                         filters tool-call noise,
                          groups by date, injects top 3 dates × 2 chunks
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -263,10 +263,13 @@ session-indexer/
 │   └── architecture.md
 ├── .claude/
 │   ├── hooks/
-│   │   ├── session-end.sh
-│   │   ├── session-last.sh
+│   │   ├── session-end.sh    — Stop: LLM summary → session-log.md
+│   │   ├── session-index.sh  — Stop: mine JSONL → sessions.db
+│   │   ├── session-last.sh   — SessionStart: inject last summary
+│   │   ├── session-recall.sh — SessionStart: semantic context injection
 │   │   └── _lib/hook-common.sh
-│   ├── skills/              — injected from common
+│   ├── skills/
+│   │   └── session-recall/SKILL.md  — /recall <query> skill
 │   └── settings.local.json
 ├── .gitignore
 ├── go.mod                   — go 1.26
@@ -322,11 +325,40 @@ Note: `--project` flag removed (redundant — DB path is per-project).
 
 ---
 
-## Open Questions
+## Integration: SessionStart Hook
 
-1. Should embeddings be generated synchronously during `mine` (blocking, slower)
-   or queued and generated in a separate `embed` pass?
-   → Synchronous for now; revisit if 60s hook timeout is hit in practice.
-2. Should `search` output be structured (JSON) for use in skills/pipes,
-   or human-readable only?
-   → Human-readable default + `--json` flag for scripting.
+`session-recall.sh` fires on every `SessionStart` event and injects semantically
+relevant past session chunks as `additionalContext`.
+
+```bash
+SESSION_START hooks:
+  1. session-last.sh   — injects last session-log.md entry (structured summary)
+  2. session-recall.sh — derives a query from git branch + last 3 commit messages,
+                         runs `session-indexer search --json`, filters tool-call noise,
+                         groups by date, injects top 3 dates × 2 chunks
+```
+
+The query is derived automatically — no user input required:
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed 's/[_\/-]/ /g')
+COMMITS=$(git log --oneline -3 | cut -d' ' -f2- | tr '\n' ' ')
+QUERY="$BRANCH $COMMITS"
+```
+
+Output format (injected as `additionalContext`):
+```
+Relevant past sessions (semantic search):
+
+### 2026-06-28
+  [0.91] We decided to use a ring buffer for the event queue to avoid allocations…
+  [0.87] The db.Open idempotency comes from INSERT OR IGNORE on the dedup index…
+
+### 2026-06-20
+  [0.82] Chunker splits on paragraph boundaries, max 1500 chars per chunk…
+```
+
+`session-recall.sh` silently no-ops if:
+- `session-indexer` is not in PATH
+- `.claude/sessions.db` does not exist yet (first session)
+- the derived query is empty (no git context)
+

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -72,6 +72,52 @@ alternative weeks ago but can't remember the exact wording.
 
 ---
 
+## UC-5: Automatic context injection at session start
+
+**Actor:** Claude Code SessionStart hook (`session-recall.sh`).
+
+**Trigger:** Val opens a new Claude Code session in this project.
+
+**Flow:**
+1. SessionStart fires: `session-recall.sh` derives a query from the current git
+   branch name + last 3 commit messages.
+2. Runs `session-indexer search "$QUERY" --db .claude/sessions.db --limit 5 --json`.
+3. Filters out tool-call noise (raw JSON blobs from Bash/Read/Write/etc.).
+4. Groups top results by date, truncates to 280 chars each.
+5. Emits a `hookSpecificOutput` JSON with `additionalContext` injected into the
+   session context by Claude Code.
+6. Claude opens the session with relevant past chunks already visible.
+
+**Success:** Claude begins the session with semantically relevant context from prior
+work — without Val having to remember to ask.
+
+**No-op conditions** (silent exit 0):
+- `session-indexer` not in PATH
+- `.claude/sessions.db` does not exist yet (first session)
+- derived query is empty (no git context)
+- search returns no chunks after noise filtering
+
+---
+
+## UC-6: Manual search via /recall skill
+
+**Actor:** Val, mid-session, wanting to search past sessions interactively.
+
+**Trigger:** Val types `/recall <query>` in Claude Code.
+
+**Flow:**
+1. Claude Code invokes `.claude/skills/session-recall/SKILL.md`.
+2. The skill runs `session-indexer search "$QUERY" --db .claude/sessions.db --limit 10 --json`.
+3. Python post-processing formats results: date · role · score · snippet (400 chars).
+4. Tool-call chunks are flagged `[tool]` but not hidden.
+5. Results printed in the session.
+
+`/recall stats` shows index state (sessions, chunks, embeddings, pending).
+
+**Success:** Val sees matching past chunks inline without leaving Claude Code.
+
+---
+
 ## UC-7: Backfill missing embeddings
 
 **Actor:** Val, after Ollama was unavailable during earlier mines.
@@ -88,7 +134,7 @@ alternative weeks ago but can't remember the exact wording.
 
 ---
 
-## UC-5: Rebuild index from existing JSONLs
+## UC-8: Rebuild index from existing JSONLs
 
 **Actor:** Val, after a DB corruption or on a new machine.
 
@@ -111,7 +157,7 @@ alternative weeks ago but can't remember the exact wording.
 
 ---
 
-## UC-6: Inspect index state
+## UC-9: Inspect index state
 
 **Actor:** Val, troubleshooting.
 


### PR DESCRIPTION
## Summary

- **README rewrite**: Prerequisites, Quick Start (6 steps), `--json` output schema, `mine` field glossary (`skipped` vs `deferred`), Troubleshooting section, Hook Setup JSON, mempalace comparison rationale
- **architecture.md**: remove stale Open Questions (both resolved); File Layout updated with session-recall hooks + skill; new SessionStart Hook section
- **use-cases.md**: fix UC numbering (UC-7 was before UC-5/6 — gap from earlier sessions); add UC-5 (automatic SessionStart injection) and UC-6 (/recall skill usage); old UC-5/6 become UC-8/9
- **`.gitignore`**: add `tmp/` (local scratch, pre-existing modification)

`.claude/` changes (local-only, not in git):
- Installed `.claude/hooks/session-recall.sh` from `~/wrk/common/skills/session-recall/`
- Added `session-recall.sh` to `settings.local.json` SessionStart hooks
- Installed `/recall` skill at `.claude/skills/session-recall/SKILL.md`

## Test plan

- [ ] `make vet && make test` — no regressions
- [ ] Verify `/recall <query>` works in this session (skill now loaded)
- [ ] End this session → check hooks.log for `session-recall.sh invoked` at next start

🤖 Generated with [Claude Code](https://claude.com/claude-code)