### PR TITLE
fix: apply five-review remediation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: CGO_ENABLED=0 go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Format check
+        run: test -z "$(gofmt -l .)"
+
+      - name: Test (race)
+        run: go test -race ./...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Extract `user` and `assistant` turns where `isMeta=false`. Skip XML/HTML (`<`), 
 
 ### Embeddings
 
-Ollama REST: `POST localhost:11434/api/embed`, model `bge-m3:latest` (1024 dims). Probe first with `GET /api/tags` (2s timeout) — if unavailable, skip embeddings and log a warning. Store as `encoding/binary` LittleEndian float32 BLOB.
+Ollama REST: `POST localhost:11434/api/embed`, model `bge-m3:latest` (1024 dims). Override with `OLLAMA_HOST` (URL or `host:port`) and `OLLAMA_MODEL` env vars. Probe first with `GET /api/tags` (2s timeout) — if unavailable, skip embeddings and log a warning. Store as `encoding/binary` LittleEndian float32 BLOB.
 
 `mine` runs with a 50s `context.Context` deadline (headroom under the 60s Stop-hook budget). Storing is fast and unconditional; embedding is the phase that respects the deadline. Chunks past the deadline are stored but flagged `Deferred` in the `Result` and left without an embedding row — backfill with `session-indexer embed`. Embed errors never abort the mine (counted as `Skipped`).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # session-indexer
 
+[![CI](https://github.com/valpere/session-indexer/actions/workflows/ci.yml/badge.svg)](https://github.com/valpere/session-indexer/actions/workflows/ci.yml)
+
 Per-project semantic search over Claude Code session history. Indexes JSONL
 transcripts into a per-project SQLite store; retrieves via bge-m3 embeddings
 (Ollama) with FTS5 BM25 fallback. Automatically injects relevant past context
@@ -96,12 +98,19 @@ FTS5 fallback mode (higher is always better in both cases).
 
 ## Embeddings
 
-Requires Ollama on `localhost:11434` with `bge-m3:latest`. `mine` runs with a
-50s `context.Context` deadline (headroom under the 60s Stop-hook budget):
-storing is fast and unconditional; embedding respects the deadline. Chunks past
-the deadline are stored but `Deferred` (no embedding row); backfill with
-`session-indexer embed`. Embed errors count as `Skipped` — same storage state,
-same backfill path, different cause.
+Requires Ollama on `localhost:11434` with `bge-m3:latest`. Override with
+environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `OLLAMA_HOST` | `http://localhost:11434` | Ollama base URL (scheme optional: `localhost:11434` works) |
+| `OLLAMA_MODEL` | `bge-m3:latest` | Embedding model name |
+
+`mine` runs with a 50s `context.Context` deadline (headroom under the 60s
+Stop-hook budget): storing is fast and unconditional; embedding respects the
+deadline. Chunks past the deadline are stored but `Deferred` (no embedding row);
+backfill with `session-indexer embed`. Embed errors count as `Skipped` — same
+storage state, same backfill path, different cause.
 
 When Ollama is unavailable or the store has zero embeddings, `search` falls back
 to FTS5 BM25 with per-term OR recall and notes this in the output.
@@ -156,6 +165,12 @@ Delete the DB and re-run `mine` on your JSONLs — `mine` is idempotent.
 session-indexer stats --db .claude/sessions.db   # check pending count
 session-indexer embed --db .claude/sessions.db   # backfill embeddings
 ```
+
+**Search warns "N chunks not yet embedded — results may be incomplete":**
+Some chunks are stored but have no embedding (interrupted mine, Ollama was
+down, or deadline hit). Cosine search only ranks embedded chunks — unembedded
+ones are invisible until backfilled. FTS5 fallback only activates when zero
+embeddings exist, not for a partial store. Fix: run `session-indexer embed`.
 
 **Read hook logs:**
 ```bash

--- a/cmd/session-indexer/main.go
+++ b/cmd/session-indexer/main.go
@@ -79,6 +79,15 @@ func main() {
 			if err != nil {
 				return err
 			}
+			// Warn when cosine was used but some chunks lack embeddings:
+			// those chunks are invisible to search until `embed` backfills them.
+			if used {
+				if st, e := search.GetStats(d, dbPath); e == nil && st.Pending > 0 {
+					fmt.Fprintf(os.Stderr,
+						"warn: %d chunks not yet embedded — results may be incomplete; run: session-indexer embed --db %s\n",
+						st.Pending, dbPath)
+				}
+			}
 			return printResults(res, used, asJSON)
 		},
 	}
@@ -143,7 +152,7 @@ func runEmbed(dbPath string) error {
 	}
 	var n, failed int
 	for _, p := range pending {
-		vec, err := emb.Embed(p.Content)
+		vec, err := emb.Embed(context.Background(), p.Content)
 		if err != nil {
 			failed++
 			continue

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-A single Go binary with three subcommands. No daemon, no server, no shared
+A single Go binary with four subcommands. No daemon, no server, no shared
 state between projects.
 
 ```
@@ -142,7 +142,7 @@ Content extraction:
 | `user` where `isMeta=false` | extract `message.content` |
 | `assistant` where `isMeta=false` | extract `message.content[].text` (type=text blocks) |
 | `tool_use` blocks (inside assistant content) | extract `name` + text fields from `input` (skip binary/path-only inputs) |
-| `tool_result` blocks (inside user content) | extract text content; skip if base64/binary heuristic (length >10KB or matches `^[A-Za-z0-9+/]{60,}`) |
+| `tool_result` blocks (inside user content) | extract text content; skip if binary heuristic (length >10KB) — regex `^[A-Za-z0-9+/]{60,}` was removed as too broad (matched valid long alphanumeric output) |
 | anything else | skip |
 
 Tool content truncation:
@@ -165,9 +165,9 @@ Chunking:
 
 Ollama REST call:
 ```
-POST http://localhost:11434/api/embed
+POST http://localhost:11434/api/embed   (default; override with OLLAMA_HOST)
 {
-  "model": "bge-m3:latest",
+  "model": "bge-m3:latest",            (default; override with OLLAMA_MODEL)
   "input": "<chunk content>"
 }
 → { "embeddings": [[float32 × 1024]] }
@@ -175,7 +175,8 @@ POST http://localhost:11434/api/embed
 
 Storage: `encoding/binary` LittleEndian float32 slice → BLOB.
 
-Cosine similarity computed in Go at query time over candidates returned by FTS5.
+Cosine similarity computed in Go at query time, exhaustively over **all** stored
+embedding vectors (FTS5 is only the fallback path, not a pre-filter).
 
 Ollama probe before embedding:
 ```
@@ -224,6 +225,14 @@ The fallback also triggers when Ollama is up but the store has zero
 embeddings (e.g. mined while Ollama was down, now back). Without this,
 cosine would return nothing and search would go blind.
 
+**Partial embedding store:** cosine search activates as soon as any
+embedding row exists (`hasEmbeddings` checks for ≥1 row). Chunks that
+are stored but not yet embedded (deferred or skipped during `mine`) are
+invisible to cosine search until `embed` backfills them — FTS fallback
+does **not** activate for a partial store. `search` warns on stderr when
+pending embeddings exist: `warn: N chunks not yet embedded — results may
+be incomplete; run: session-indexer embed --db <path>`.
+
 **Scale assumption:** personal session recall, <10k chunks (~40MB vectors in-memory).
 Revisit if index exceeds 50k chunks.
 
@@ -261,7 +270,8 @@ session-indexer/
 │   ├── requirements.md
 │   ├── use-cases.md
 │   └── architecture.md
-├── .claude/
+├── .claude/                   — LOCAL ONLY (gitignored, not committed)
+│   │                            Canonical source: ~/wrk/common/skills/session-recall/
 │   ├── hooks/
 │   │   ├── session-end.sh    — Stop: LLM summary → session-log.md
 │   │   ├── session-index.sh  — Stop: mine JSONL → sessions.db

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,6 +1,6 @@
 # Requirements: session-indexer
 
-Source: `~/wrk/common/investigations/session-recall-semantic-search.md`
+Source: [`docs/investigation/session-recall-semantic-search.md`](investigation/session-recall-semantic-search.md)
 
 ---
 

--- a/docs/review-consilium.md
+++ b/docs/review-consilium.md
@@ -57,7 +57,7 @@ Added `message_index` and `chunk_index` columns to schema. `created_at` kept for
 
 ### H5. No schema migration strategy (claude, cursor, kilo)
 
-✅ Resolved: `meta` table with `schema_version`; mismatch → error + "run reindex".
+✅ Resolved: `meta` table with `schema_version`; mismatch → error + "delete the DB and re-mine" (there is no `reindex` subcommand).
 
 ### H6. Large tool outputs pass noise filter (claude)
 

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -3,18 +3,22 @@ package embed
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 )
 
 // Embedder produces vectors and reports availability.
 type Embedder interface {
 	Available() bool
-	Embed(text string) ([]float32, error)
+	Embed(ctx context.Context, text string) ([]float32, error)
 }
 
 // Client is an Ollama-backed Embedder.
@@ -24,8 +28,24 @@ type Client struct {
 	http    *http.Client
 }
 
-// NewClient returns a client for local Ollama with the bge-m3 model.
-func NewClient() *Client { return NewClientURL("http://localhost:11434", "bge-m3:latest") }
+// NewClient returns a client configured from environment:
+//
+//	OLLAMA_HOST  — base URL (default: http://localhost:11434);
+//	               if value has no scheme, http:// is prepended
+//	OLLAMA_MODEL — embedding model (default: bge-m3:latest)
+func NewClient() *Client {
+	baseURL := os.Getenv("OLLAMA_HOST")
+	if baseURL == "" {
+		baseURL = "http://localhost:11434"
+	} else if !strings.Contains(baseURL, "://") {
+		baseURL = "http://" + baseURL
+	}
+	model := os.Getenv("OLLAMA_MODEL")
+	if model == "" {
+		model = "bge-m3:latest"
+	}
+	return NewClientURL(baseURL, model)
+}
 
 // NewClientURL builds a client against an arbitrary base URL (tests).
 func NewClientURL(baseURL, model string) *Client {
@@ -57,13 +77,26 @@ func (c *Client) Available() bool {
 }
 
 // Embed returns the embedding for text via POST /api/embed.
-func (c *Client) Embed(text string) ([]float32, error) {
+// The request is cancelled when ctx is done, enforcing the caller's deadline.
+// A 30s HTTP client timeout acts as a per-call backstop.
+func (c *Client) Embed(ctx context.Context, text string) ([]float32, error) {
 	body, _ := json.Marshal(map[string]any{"model": c.model, "input": text})
-	resp, err := c.http.Post(c.baseURL+"/api/embed", "application/json", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/api/embed", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("ollama embed: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("ollama embed: %w", err)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return nil, fmt.Errorf("ollama embed: status %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
 	var out struct {
 		Embeddings [][]float32 `json:"embeddings"`
 	}

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -1,9 +1,11 @@
 package embed
 
 import (
+	"context"
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -54,11 +56,46 @@ func TestEmbedReturnsVector(t *testing.T) {
 	}))
 	defer srv.Close()
 	c := NewClientURL(srv.URL, "bge-m3:latest")
-	v, err := c.Embed("hello")
+	v, err := c.Embed(context.Background(), "hello")
 	if err != nil {
 		t.Fatalf("Embed: %v", err)
 	}
 	if len(v) != 3 || v[0] != 0.5 {
 		t.Fatalf("vector = %v", v)
+	}
+}
+
+// TestEmbedSurfacesHTTPStatus verifies that a non-2xx response returns a
+// useful status error instead of a vague decode failure.
+func TestEmbedSurfacesHTTPStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"model loading failed"}`))
+	}))
+	defer srv.Close()
+	c := NewClientURL(srv.URL, "bge-m3:latest")
+	_, err := c.Embed(context.Background(), "test")
+	if err == nil {
+		t.Fatal("expected error for 500 response, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("error should mention status 500, got: %v", err)
+	}
+}
+
+// TestEmbedRespectsContextCancellation verifies that a cancelled ctx aborts
+// the HTTP request — this is the mechanism that enforces the 50s mine deadline.
+func TestEmbedRespectsContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Block until the client cancels.
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+	c := NewClientURL(srv.URL, "bge-m3:latest")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+	_, err := c.Embed(ctx, "test")
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
 	}
 }

--- a/internal/mine/mine.go
+++ b/internal/mine/mine.go
@@ -75,7 +75,7 @@ func Run(ctx context.Context, dbPath, jsonlPath string, emb embed.Embedder) (Res
 			res.Deferred++
 			continue
 		}
-		vec, err := emb.Embed(p.content)
+		vec, err := emb.Embed(ctx, p.content)
 		if err != nil {
 			res.Skipped++
 			continue

--- a/internal/mine/mine_test.go
+++ b/internal/mine/mine_test.go
@@ -12,7 +12,7 @@ import (
 type fakeEmbedder struct{ avail bool }
 
 func (f fakeEmbedder) Available() bool { return f.avail }
-func (f fakeEmbedder) Embed(string) ([]float32, error) {
+func (f fakeEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
 	return []float32{0.1, 0.2, 0.3}, nil
 }
 
@@ -56,8 +56,10 @@ func TestRunIdempotent(t *testing.T) {
 
 type errEmbedder struct{}
 
-func (e errEmbedder) Available() bool                 { return true }
-func (e errEmbedder) Embed(string) ([]float32, error) { return nil, fmt.Errorf("embed failed") }
+func (e errEmbedder) Available() bool { return true }
+func (e errEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return nil, fmt.Errorf("embed failed")
+}
 
 func TestRunSkippedOnEmbedError(t *testing.T) {
 	jsonl := `{"type":"user","sessionId":"s1","timestamp":"2026-06-25T10:00:00Z","message":{"role":"user","content":"This is a long enough question about database design choices."}}`

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -3,6 +3,7 @@
 package search
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"math"
@@ -35,7 +36,7 @@ func hasEmbeddings(d *sql.DB) bool {
 }
 
 func cosineSearch(d *sql.DB, emb embed.Embedder, query string, limit int) ([]internal.SearchResult, error) {
-	qv, err := emb.Embed(query)
+	qv, err := emb.Embed(context.Background(), query)
 	if err != nil {
 		return nil, fmt.Errorf("embed query: %w", err)
 	}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -15,7 +16,7 @@ type stubEmbedder struct {
 }
 
 func (s stubEmbedder) Available() bool { return s.avail }
-func (s stubEmbedder) Embed(text string) ([]float32, error) {
+func (s stubEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
 	if v, ok := s.vecs[text]; ok {
 		return v, nil
 	}


### PR DESCRIPTION
## Summary

Applies the validated findings from five independent codebase reviews (agy, codex, cursor, kilo, opencode). Only findings verified against the actual source and aligned with the project's KISS/YAGNI principles are included.

- **Context-aware `Embed`**: `Embedder.Embed` now accepts `context.Context`; the 50s mine deadline actually cancels in-flight Ollama HTTP calls (previously only checked between calls)
- **HTTP status check**: `Client.Embed` checks `resp.StatusCode`; returns `"status 500: ..."` instead of a vague decode error
- **Partial-embedding warn**: `search` warns on stderr when cosine mode is active but `pending > 0` — those chunks are invisible until `embed` backfills them
- **`OLLAMA_HOST` / `OLLAMA_MODEL` env vars**: override hardcoded defaults in `NewClient`; bare `host:port` gets `http://` prepended
- **GitHub Actions CI**: `build + vet + gofmt check + test-race` on every push/PR
- **Doc drift (6 spots)**: subcommand count, cosine algorithm description, stale base64 heuristic note, `.claude/` layout annotation, private path in `requirements.md`, stale "reindex" in `review-consilium.md`

## Test plan

- [ ] `go vet ./...` — clean
- [ ] `gofmt -l .` — empty
- [ ] `go test -race ./...` — 29 tests pass (2 new: `TestEmbedSurfacesHTTPStatus`, `TestEmbedRespectsContextCancellation`)
- [ ] CI workflow runs green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)