### PR TITLE
feat: add semver version support (v0.1.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,16 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | awk 'BEGIN {FS=":.*?##"}; {printf "  %-12s %s\n", $$1, $$2}'
 	@echo "Run \`make -n <target>\` to see what a target does."
 
-BINARY := bin/session-indexer
+BINARY   := bin/session-indexer
 TEST_PKG ?= ./...
+VERSION  := $(shell git describe --tags --exact-match 2>/dev/null || echo "0.1.0")
+LDFLAGS  := -ldflags "-X main.version=$(VERSION)"
 
 build: ## build to bin/session-indexer
-	go build -o $(BINARY) ./cmd/session-indexer
+	go build $(LDFLAGS) -o $(BINARY) ./cmd/session-indexer
 
 install: ## go install (puts binary on PATH)
-	go install ./cmd/session-indexer
+	go install $(LDFLAGS) ./cmd/session-indexer
 
 test: ## go test ./...
 	go test $(TEST_PKG)

--- a/cmd/session-indexer/main.go
+++ b/cmd/session-indexer/main.go
@@ -16,12 +16,17 @@ import (
 	"github.com/valpere/session-indexer/internal/search"
 )
 
+// version is the current release; overridden at build time via
+// -ldflags "-X main.version=x.y.z" (see Makefile).
+var version = "0.1.0"
+
 func main() {
 	var dbPath string
 
 	root := &cobra.Command{
 		Use:           "session-indexer",
 		Short:         "Index and semantically search Claude Code sessions",
+		Version:       version,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}


### PR DESCRIPTION
## Summary

- `var version = "0.1.0"` in `main.go`, overrideable at build time via `-ldflags "-X main.version=x.y.z"`
- `root.Version = version` gives `session-indexer --version` for free via Cobra
- Makefile injects `VERSION` (from `git describe --tags --exact-match`, fallback `0.1.0`) into both `build` and `install` targets

## Test plan

- [ ] `make build && ./bin/session-indexer --version` → `session-indexer version 0.1.0`
- [ ] `go test -race ./...` — 29 tests pass
- [ ] After tagging `v0.1.0`: `make build && ./bin/session-indexer --version` → `session-indexer version 0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)