### PR TITLE
test: add regression tests (binary filter, noise boundary, cosine edge-cases)

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -71,6 +71,43 @@ func TestOpenVersionMismatch(t *testing.T) {
 	}
 }
 
+func TestChunksWithoutEmbeddingsEmptyDB(t *testing.T) {
+	d, _ := Open(tempDB(t))
+	defer d.Close()
+	pending, err := ChunksWithoutEmbeddings(d)
+	if err != nil {
+		t.Fatalf("ChunksWithoutEmbeddings on empty DB: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("empty DB has %d pending chunks, want 0", len(pending))
+	}
+}
+
+func TestInsertEmbeddingReplacement(t *testing.T) {
+	// INSERT OR REPLACE must overwrite the previous embedding, not duplicate it.
+	d, _ := Open(tempDB(t))
+	defer d.Close()
+	c := internal.Chunk{SessionID: "s1", SessionDate: "2026-06-25", Role: "user",
+		MessageIndex: 0, ChunkIndex: 0, Content: "test chunk content here", CreatedAt: "2026-06-25T10:00:00Z"}
+	id, _, _ := InsertChunk(d, c)
+	if err := InsertEmbedding(d, id, []byte{1, 0, 0, 0}); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	if err := InsertEmbedding(d, id, []byte{2, 0, 0, 0}); err != nil {
+		t.Fatalf("second insert (replace): %v", err)
+	}
+	var count int
+	d.QueryRow(`SELECT COUNT(*) FROM embeddings WHERE chunk_id=?`, id).Scan(&count)
+	if count != 1 {
+		t.Fatalf("embedding count = %d, want 1 (INSERT OR REPLACE)", count)
+	}
+	var blob []byte
+	d.QueryRow(`SELECT vector FROM embeddings WHERE chunk_id=?`, id).Scan(&blob)
+	if len(blob) == 0 || blob[0] != 2 {
+		t.Fatalf("stored vector first byte = %v, want 2 (latest value)", blob)
+	}
+}
+
 func TestInsertEmbeddingAndPendingList(t *testing.T) {
 	d, _ := Open(tempDB(t))
 	defer d.Close()

--- a/internal/mine/chunk_test.go
+++ b/internal/mine/chunk_test.go
@@ -52,6 +52,33 @@ func TestChunkSplitsLongMessage(t *testing.T) {
 	}
 }
 
+func TestChunkNoiseBoundary(t *testing.T) {
+	// 29 chars = noise; 30 chars = kept.
+	short := strings.Repeat("a", 29)
+	exact := strings.Repeat("a", 30)
+	if got := ChunkMessages([]Message{msg(short)}); len(got) != 0 {
+		t.Errorf("29-char content produced %d chunks, want 0 (noise)", len(got))
+	}
+	if got := ChunkMessages([]Message{msg(exact)}); len(got) != 1 {
+		t.Errorf("30-char content produced %d chunks, want 1", len(got))
+	}
+}
+
+func TestChunkEmptyTimestampFallsBack(t *testing.T) {
+	m := Message{SessionID: "s1", Role: "user", MessageIndex: 0,
+		Content: "long enough content to not be filtered by noise", Timestamp: ""}
+	got := ChunkMessages([]Message{m})
+	if len(got) != 1 {
+		t.Fatalf("got %d chunks, want 1", len(got))
+	}
+	if got[0].SessionDate == "" {
+		t.Fatal("SessionDate empty, want fallback date")
+	}
+	if got[0].CreatedAt == "" {
+		t.Fatal("CreatedAt empty, want fallback timestamp")
+	}
+}
+
 func TestChunkCyrillicHardSplit(t *testing.T) {
 	// 1600 Cyrillic runes × 2 bytes each = 3200 bytes, single paragraph (no \n\n).
 	// Old byte-indexing would corrupt at byte 1500 (mid-rune); rune-aware split must

--- a/internal/mine/parse_test.go
+++ b/internal/mine/parse_test.go
@@ -52,3 +52,69 @@ func TestParseTruncatesLargeToolBlock(t *testing.T) {
 		t.Fatalf("tool block not truncated: len=%d", len(msgs[0].Content))
 	}
 }
+
+func TestParseToolResultBlockArray(t *testing.T) {
+	// tool_result with content as a block array of text blocks (not a plain string).
+	jsonl := `{"type":"assistant","sessionId":"s1","message":{"role":"assistant","content":[{"type":"tool_result","content":[{"type":"text","text":"hello from tool result"}]}]}}`
+	msgs, _ := ParseJSONL(strings.NewReader(jsonl), "f")
+	if len(msgs) != 1 {
+		t.Fatalf("got %d messages, want 1", len(msgs))
+	}
+	if !strings.Contains(msgs[0].Content, "hello from tool result") {
+		t.Fatalf("content = %q, want tool result text", msgs[0].Content)
+	}
+}
+
+func TestParseToolResultBinaryDropped(t *testing.T) {
+	// content > 10 KB triggers isBinary → filtered, entire message skipped.
+	big := strings.Repeat("x", 10241)
+	jsonl := `{"type":"assistant","sessionId":"s1","message":{"role":"assistant","content":[{"type":"tool_result","content":"` + big + `"}]}}`
+	msgs, _ := ParseJSONL(strings.NewReader(jsonl), "f")
+	if len(msgs) != 0 {
+		t.Fatalf("got %d messages, want 0 (binary content must be dropped)", len(msgs))
+	}
+}
+
+func TestParseToolUseExtracted(t *testing.T) {
+	jsonl := `{"type":"assistant","sessionId":"s1","message":{"role":"assistant","content":[{"type":"tool_use","name":"Write","input":{"path":"foo.go","content":"package main"}}]}}`
+	msgs, _ := ParseJSONL(strings.NewReader(jsonl), "f")
+	if len(msgs) != 1 {
+		t.Fatalf("got %d messages, want 1", len(msgs))
+	}
+	if !strings.Contains(msgs[0].Content, "Write") {
+		t.Fatalf("content = %q, want tool_use name present", msgs[0].Content)
+	}
+}
+
+func TestParseMalformedLineSkipped(t *testing.T) {
+	jsonl := strings.Join([]string{
+		`{"type":"user","sessionId":"s1","message":{"role":"user","content":"first message here"}}`,
+		`{not valid json`,
+		`{"type":"user","sessionId":"s1","message":{"role":"user","content":"third message here"}}`,
+	}, "\n")
+	msgs, err := ParseJSONL(strings.NewReader(jsonl), "f")
+	if err != nil {
+		t.Fatalf("ParseJSONL: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("got %d messages, want 2 (malformed line must be skipped)", len(msgs))
+	}
+}
+
+func TestTruncToolShortPassthrough(t *testing.T) {
+	s := "short string"
+	if got := truncTool(s); got != s {
+		t.Fatalf("truncTool short = %q, want unchanged", got)
+	}
+}
+
+func TestTruncToolExactBoundary(t *testing.T) {
+	at := strings.Repeat("x", toolBlockCap)
+	over := at + "!"
+	if got := truncTool(at); got != at {
+		t.Fatalf("at cap: expected passthrough, got len=%d", len(got))
+	}
+	if got := truncTool(over); !strings.HasSuffix(got, "[truncated]") {
+		t.Fatalf("over cap: expected [truncated] suffix, got len=%d", len(got))
+	}
+}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -135,6 +135,31 @@ func TestSearchFTSMatchesNonAdjacentTerms(t *testing.T) {
 	}
 }
 
+func TestCosineZeroVector(t *testing.T) {
+	a := []float32{0, 0, 0}
+	b := []float32{1, 0, 0}
+	if got := cosine(a, b); got != 0 {
+		t.Fatalf("cosine(zero, x) = %v, want 0", got)
+	}
+	if got := cosine(a, a); got != 0 {
+		t.Fatalf("cosine(zero, zero) = %v, want 0", got)
+	}
+}
+
+func TestCosineMismatchedLength(t *testing.T) {
+	a := []float32{1, 0}
+	b := []float32{1, 0, 0}
+	if got := cosine(a, b); got != 0 {
+		t.Fatalf("cosine(mismatched lengths) = %v, want 0", got)
+	}
+}
+
+func TestCosineEmptyVectors(t *testing.T) {
+	if got := cosine(nil, nil); got != 0 {
+		t.Fatalf("cosine(nil, nil) = %v, want 0", got)
+	}
+}
+
 func TestGetStats(t *testing.T) {
 	dbp := seed(t, stubEmbedder{avail: true})
 	d, _ := db.Open(dbp)


### PR DESCRIPTION
## Summary

- **parse**: `tool_result` block-array extraction, binary drop (>10 KB threshold), `tool_use` extraction, malformed-line skip, `truncTool` passthrough + exact-at-cap boundary
- **chunk**: 29/30-char noise boundary, empty-timestamp fallback to today
- **search**: `cosine` with zero vectors, mismatched lengths, nil vectors
- **db**: `ChunksWithoutEmbeddings` on empty DB, `InsertEmbedding` OR REPLACE overwrites (not duplicates)

## Coverage delta

| Function | Before | After |
|---|---|---|
| `toolResultText` | 30.8% | 84.6% |
| `truncTool` | 66.7% | 100% |
| `extractContent` | 76.2% | 90.5% |
| `ChunkMessages` | 87.5% | 100% |
| Total | 61.4% | 65.3% |

## Test plan

- [x] `go test -race ./...` — 42 tests, all pass
- [x] `gofmt -l .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)