### PR TITLE
ci: release workflow, govulncheck security scan, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binaries
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          LDFLAGS="-X main.version=${VERSION}"
+          mkdir -p dist
+          for platform in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64; do
+            GOOS="${platform%/*}"
+            GOARCH="${platform#*/}"
+            out="dist/session-indexer_${VERSION}_${GOOS}_${GOARCH}"
+            [ "$GOOS" = "windows" ] && out="${out}.exe"
+            CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH \
+              go build -ldflags "$LDFLAGS" -o "$out" ./cmd/session-indexer
+            echo "built $out"
+          done
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
             GOOS="${platform%/*}"
             GOARCH="${platform#*/}"
             out="dist/session-indexer_${VERSION}_${GOOS}_${GOARCH}"
-            [ "$GOOS" = "windows" ] && out="${out}.exe"
+            if [ "$GOOS" = "windows" ]; then out="${out}.exe"; fi
             CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH \
               go build -ldflags "$LDFLAGS" -o "$out" ./cmd/session-indexer
             echo "built $out"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,23 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  vulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   vulncheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- **`release.yml`** — triggers on `v*` tags; cross-compiles 5 binaries (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64) with `-X main.version=${TAG}` ldflags injected; creates a GitHub Release via `softprops/action-gh-release@v2` with auto-generated release notes
- **`security.yml`** — runs `govulncheck ./...` on push to `main` and on PRs targeting `main`; catches known Go module CVEs before merge
- **`dependabot.yml`** — weekly PRs for `gomod` and `github-actions` ecosystems; max 5 open PRs each

## Test plan

- [ ] Push a `v0.1.0` tag after merge to verify release binaries appear on the Releases page
- [ ] Confirm `security` check appears in PR checks on the next PR
- [ ] Confirm Dependabot PRs appear within a week

🤖 Generated with [Claude Code](https://claude.com/claude-code)