### PR TITLE
refactor: drop python3 dependency — replace with jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ can break another.
 - **Ollama** — for vector embeddings (optional but recommended)
   - Install: [ollama.com/download](https://ollama.com/download) — native packages for macOS, Linux, Windows
   - `ollama pull bge-m3:latest` — 1024-dim multilingual model (EN + UA)
-- **jq** — used by the SessionStart hook to format the hook output JSON
-- **python3** — used by the `/recall` skill and `session-recall.sh` for output formatting
+- **jq** — used by hooks and `/recall` for JSON formatting
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- `session-recall.sh` and `/recall` SKILL.md used inline `python3` scripts for JSON formatting (filter tool-call noise, group by date, truncate, score display)
- Both replaced with `jq -r` pipelines with equivalent logic — no new dependencies; `jq` is already required by the hook layer
- README Prerequisites: removed `python3` entry, consolidated `jq` description

Note: `.claude/` is gitignored so the hook/skill changes are local-only; this PR tracks only the README update.

## Test plan

- [ ] Smoke-tested both jq pipelines locally with sample JSON (tool-call filtering, grouping, truncation all verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)