### PR TITLE
docs: update UC-6 — python → jq for /recall formatting

### DIFF
--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -108,7 +108,7 @@ work — without Val having to remember to ask.
 **Flow:**
 1. Claude Code invokes `.claude/skills/session-recall/SKILL.md`.
 2. The skill runs `session-indexer search "$QUERY" --db .claude/sessions.db --limit 10 --json`.
-3. Python post-processing formats results: date · role · score · snippet (400 chars).
+3. `jq` formats results: date · role · score · snippet (400 chars).
 4. Tool-call chunks are flagged `[tool]` but not hidden.
 5. Results printed in the session.
 


### PR DESCRIPTION
## Summary

- `docs/use-cases.md` UC-6 still said "Python post-processing formats results" after PR #18 dropped the python3 dependency
- Updated to reflect the jq pipeline now used by the `/recall` skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)