### PR TITLE
docs: document orchestrator/subagent recall pattern

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -279,7 +279,7 @@ session-indexer/
 │   │   ├── session-recall.sh — SessionStart: semantic context injection
 │   │   └── _lib/hook-common.sh
 │   ├── skills/
-│   │   └── session-recall/SKILL.md  — /recall <query> skill
+│   │   └── session-recall/SKILL.md  — /recall <query> skill + orchestrator subagent-prep section
 │   └── settings.local.json
 ├── .gitignore
 ├── go.mod                   — go 1.26
@@ -372,4 +372,24 @@ Relevant past sessions (semantic search):
 - `session-indexer` is not in PATH
 - `.claude/sessions.db` does not exist yet (first session)
 - the derived query is empty (no git context)
+
+---
+
+## Orchestrator / Subagent Recall Pattern
+
+Subagents spawned via the Agent tool start cold — no `SessionStart` hook, no
+shared context. `.claude/skills/session-recall/SKILL.md` documents a second
+entrypoint, distinct from `/recall`, meant for the *orchestrator* to invoke
+before spawning a subagent whose task benefits from project history:
+
+```bash
+session-indexer search "<query>" --db .claude/sessions.db --limit 5 --json \
+  | jq -r '.[] | "[\(.SessionDate) · \(.Role)] \(.Content[0:300])"'
+```
+
+Results are folded into the subagent's prompt (subagent prompts must be
+self-contained). This is orchestrator-side only: current subagent tool
+allowlists (`bug-fixer`, `code-generator`, `tech-lead`, etc.) exclude the
+`Skill` tool, so a spawned subagent cannot invoke `/recall` or this
+entrypoint itself mid-task.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -378,9 +378,10 @@ Relevant past sessions (semantic search):
 ## Orchestrator / Subagent Recall Pattern
 
 Subagents spawned via the Agent tool start cold — no `SessionStart` hook, no
-shared context. `.claude/skills/session-recall/SKILL.md` documents a second
-entrypoint, distinct from `/recall`, meant for the *orchestrator* to invoke
-before spawning a subagent whose task benefits from project history:
+shared context. `.claude/skills/session-recall/SKILL.md` documents the same
+`search` subcommand used by `/recall`, but for a different caller: the
+*orchestrator*, invoking it directly before spawning a subagent whose task
+benefits from project history (rather than through the Skill tool):
 
 ```bash
 session-indexer search "<query>" --db .claude/sessions.db --limit 5 --json \

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -174,3 +174,28 @@ work — without Val having to remember to ask.
    ```
 
 **Success:** Val understands the state of the index without opening SQLite directly.
+
+---
+
+## UC-10: Orchestrator recalls history before spawning a subagent
+
+**Actor:** Claude Code orchestrating agent (main session), about to delegate
+work via the Agent tool.
+
+**Trigger:** A subagent's task (e.g. an architecture decision, a bug
+diagnosis) would benefit from prior discussion in this project, but
+subagents start cold — no `SessionStart` hook, no shared context.
+
+**Flow:**
+1. Orchestrator runs `session-indexer search "<query>" --db .claude/sessions.db --limit 5 --json` directly — documented in `.claude/skills/session-recall/SKILL.md` under "For orchestrators / subagent prep".
+2. Formats results with `jq` (date, role, snippet — no noise filtering, unlike `/recall`).
+3. Folds the relevant snippets into the subagent's prompt, since subagent prompts must be self-contained.
+
+**Success:** The subagent starts with accurate historical context instead of
+re-deriving decisions already made, without the subagent itself needing
+search access.
+
+**Limitation:** Orchestrator-side only — current subagent tool allowlists
+(`bug-fixer`, `code-generator`, `tech-lead`, etc.) exclude the `Skill` tool,
+so a spawned subagent cannot invoke `/recall` or this entrypoint itself
+mid-task.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -188,7 +188,10 @@ subagents start cold — no `SessionStart` hook, no shared context.
 
 **Flow:**
 1. Orchestrator runs `session-indexer search "<query>" --db .claude/sessions.db --limit 5 --json` directly — documented in `.claude/skills/session-recall/SKILL.md` under "For orchestrators / subagent prep".
-2. Formats results with `jq` (date, role, snippet — no noise filtering, unlike `/recall`).
+2. Formats results with `jq` (date, role, snippet). Unlike `/recall`, this
+   path skips the tool-call noise filter (the regex that drops raw
+   Bash/Read/Write/etc. JSON blobs) — the orchestrator curates what goes
+   into the subagent prompt anyway.
 3. Folds the relevant snippets into the subagent's prompt, since subagent prompts must be self-contained.
 
 **Success:** The subagent starts with accurate historical context instead of


### PR DESCRIPTION
## Summary

- Added UC-10 to `docs/use-cases.md`: orchestrator recalls project history via `session-indexer search` before spawning a subagent, folding results into its prompt
- Added matching "Orchestrator / Subagent Recall Pattern" section to `docs/architecture.md`
- Updated the file-layout comment referencing `session-recall/SKILL.md`

Context: `.claude/skills/session-recall/SKILL.md` is gitignored (local-only) and already has a new "For orchestrators / subagent prep" section documenting the same command — these docs make the pattern discoverable from tracked project docs too, since the skill file itself isn't in git.

Note: subagent tool allowlists (`bug-fixer`, `code-generator`, `tech-lead`, etc.) exclude the `Skill` tool, so this is explicitly an orchestrator-invokes-before-spawning pattern, not subagent-autonomous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)