### PR TITLE
chore: sync fixes and additions from ~/wrk/common skill library

### DIFF
--- a/.claude/agents/code-generator.md
+++ b/.claude/agents/code-generator.md
@@ -1,7 +1,7 @@
 ---
 name: code-generator
 description: "Use when a tech-lead-approved plan needs to be implemented — branch, code, tests, pre-flight, PR. Requires a tech-lead-approved plan before starting. Never writes documentation or modifies files outside the agreed plan scope.\n\n<example>\nContext: The tech-lead has reviewed and approved a plan for adding a new feature.\nuser: \"Plan approved — implement it\"\nassistant: \"I'll use the code-generator agent to implement the approved plan.\"\n<commentary>An approved plan is the trigger. code-generator handles branch, implementation, tests, and PR creation.</commentary>\n</example>\n\n<example>\nContext: A GitHub issue has been approved by the Tech Lead.\nuser: \"Implement issue #42\"\nassistant: \"I'll launch the code-generator agent to implement this issue.\"\n<commentary>A tech-lead-approved issue is a clear trigger for code-generator.</commentary>\n</example>"
-tools: Bash, Glob, Grep, Read, Edit, Write, LSP
+tools: Bash, Glob, Grep, Read, Edit, Write, LSP, Agent
 model: sonnet
 color: yellow
 ---

--- a/.claude/skills/doubt-driven-development/SKILL.md
+++ b/.claude/skills/doubt-driven-development/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: doubt-driven-development
+description: Subjects every non-trivial decision to a fresh-context adversarial review before it stands. Use when correctness matters more than speed, when working in unfamiliar code, when stakes are high (production, security-sensitive logic, irreversible operations), or any time a confident output would be cheaper to verify now than to debug later.
+---
+
+# Skill: doubt-driven-development
+# Adversarial Fresh-Context Review, In-Flight
+
+Adapted from [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills)
+(MIT) — genuinely self-contained, kept close to verbatim. Complements
+`comprehension-gate` (that skill verifies the *human* understands a
+hard-to-reverse action; this one has the *agent* doubt its own non-trivial
+decisions before they stand) and `improve`/`tech-lead` (those are post-hoc
+verdicts on a finished artifact; this is in-flight, while course-correction
+is still cheap).
+
+## Overview
+
+A confident answer is not a correct one. Long sessions accumulate context that quietly turns assumptions into "facts" without anyone noticing. Doubt-driven development is the discipline of materializing a fresh-context reviewer — biased to **disprove**, not approve — before any non-trivial output stands.
+
+This is not `/review`. `/review` is a verdict on a finished artifact. This is an in-flight posture: non-trivial decisions get cross-examined while course-correction is still cheap.
+
+## When to Use
+
+A decision is **non-trivial** when at least one of these is true:
+
+- It introduces or modifies branching logic
+- It crosses a module or service boundary
+- It asserts a property the type system or compiler cannot verify (thread safety, idempotence, ordering, invariants)
+- Its correctness depends on context the future reader cannot see
+- Its blast radius is irreversible (production deploy, data migration, public API change)
+
+Apply the skill when:
+
+- About to make an architectural decision under uncertainty
+- About to commit non-trivial code
+- About to claim a non-obvious fact ("this is safe", "this scales", "this matches the spec")
+- Working in code you don't fully understand
+
+**When NOT to use:**
+
+- Mechanical operations (renaming, formatting, file moves)
+- Following a clear, unambiguous user instruction
+- Reading or summarizing existing code
+- One-line changes with obvious correctness
+- Pure tooling operations (running tests, listing files)
+- The user has explicitly asked for speed over verification
+
+If you doubt every keystroke, you ship nothing. The skill applies only to non-trivial decisions as defined above.
+
+## Loading Constraints
+
+This skill is designed for the **main-session orchestrator**, where Step 3 (DOUBT, detailed below) can spawn a fresh-context reviewer.
+
+- **Do not install this skill into a subagent's tool access expecting it to self-trigger there.** Confirmed by an empirical canary test (2026-07-07, `tumanomir`): subagents don't auto-trigger skills even with `Skill` explicitly granted in `tools:` — the agent's own system prompt dominates. This skill's Step 3 (spawning a fresh-context reviewer) only works reliably from the main-session orchestrator.
+- **If you find yourself applying this skill from inside a subagent context** (where nested subagent spawn is unavailable): the preferred path is to surface to the user that doubt-driven cannot run nested and let the main session handle it. As a last resort only, a degraded self-questioning fallback exists — rewrite ARTIFACT + CONTRACT as a fresh self-prompt with a hard mental separator from your prior reasoning, and walk Steps 1–5. This is **not fresh-context review** (you carry your own context with you), so flag the result as degraded and prefer escalation whenever the user is reachable.
+
+## The Process
+
+Copy this checklist when applying the skill:
+
+```
+Doubt cycle:
+- [ ] Step 1: CLAIM — wrote the claim + why-it-matters
+- [ ] Step 2: EXTRACT — isolated artifact + contract, stripped reasoning
+- [ ] Step 3: DOUBT — invoked fresh-context reviewer with adversarial prompt
+- [ ] Step 4: RECONCILE — classified every finding against the artifact text
+- [ ] Step 5: STOP — met stop condition (trivial findings, 3 cycles, or user override)
+```
+
+### Step 1: CLAIM — Surface what stands
+
+Name the decision in two or three lines:
+
+```
+CLAIM: "The new caching layer is thread-safe under the
+        read-heavy workload described in the spec."
+WHY THIS MATTERS: a race here corrupts user data and is
+                  hard to detect in QA.
+```
+
+If you can't write the claim that compactly, you have a vibe, not a decision. Surface it before scrutinizing it.
+
+### Step 2: EXTRACT — Smallest reviewable unit
+
+A fresh-context reviewer needs the **artifact** and the **contract**, not the journey.
+
+- Code: the diff or the function — not the whole file
+- Decision: the proposal in 3–5 sentences plus the constraints it has to satisfy
+- Assertion: the claim plus the evidence that supposedly supports it (kept distinct from the Step 1 CLAIM block, which is the orchestrator's hypothesis under scrutiny)
+
+Strip your reasoning. If you hand over conclusions, you'll get back validation of your conclusions. The unit must be small enough that a reviewer can hold it in mind in one read — if it's a 500-line PR, decompose first.
+
+### Step 3: DOUBT — Invoke the fresh-context reviewer
+
+The reviewer's prompt **must be adversarial**. Framing decides the answer.
+
+```
+Adversarial review. Find what is wrong with this artifact.
+Assume the author is overconfident. Look for:
+- Unstated assumptions
+- Edge cases not handled
+- Hidden coupling or shared state
+- Ways the contract could be violated
+- Existing conventions this might break
+- Failure modes under unexpected input
+
+Do NOT validate. Do NOT summarize. Find issues, or state
+explicitly that you cannot find any after thorough examination.
+
+ARTIFACT: <paste artifact>
+CONTRACT: <paste contract>
+```
+
+**Pass ARTIFACT + CONTRACT only. Do NOT pass the CLAIM.** Handing the reviewer your conclusion biases it toward agreement. The reviewer must independently determine whether the artifact satisfies the contract.
+
+In this library's agents (`~/wrk/common/agents/`), `tech-lead`, `static-analysis`, and `bug-fixer` start with isolated context by design and are usable here — pick whichever's domain matches the artifact.
+
+**The adversarial prompt above takes precedence over the agent's default response shape.** Agents like `tech-lead` are written to produce balanced verdicts with both strengths and weaknesses; doubt-driven needs issues-only output. Paste the adversarial prompt verbatim into the invocation so it overrides the agent's default. If an agent's response shape can't be overridden cleanly, fall back to a generic subagent with the adversarial prompt.
+
+#### Cross-model escalation
+
+A single-model reviewer shares blind spots with the original author — a colder, different-architecture model catches them. Doubt-driven is already opt-in for non-trivial decisions, so within that scope offering cross-model is part of the skill's value, not optional friction.
+
+**Interactive sessions: always offer. Never silently skip.**
+
+**Step 1: Ask the user**
+
+After the single-model review in Step 3 above, but before RECONCILE, pause and ask:
+
+> *"Single-model review complete. Want a cross-model second opinion? Options: Gemini CLI, Codex CLI, manual external review (you paste it elsewhere), or skip."*
+
+This question is mandatory in every interactive doubt cycle — even on artifacts that feel low-stakes. The user — not the agent — decides whether the cost is worth it. The agent's job is to surface the choice.
+
+**Step 2: If the user picks a CLI — verify, then invoke**
+
+1. Check the tool is in PATH (`which gemini`, `which codex`).
+2. Test it works (`gemini --version` or equivalent) before passing the full prompt — a stale or broken binary may pass `which` but fail on real input.
+3. Confirm the exact invocation with the user, including required flags, auth, and env vars (e.g., API keys). Implementations vary; never assume.
+4. Pass ARTIFACT + CONTRACT + the adversarial prompt **only**. No session context, no CLAIM.
+5. Mind shell escaping. If the artifact contains quotes, `$(...)`, or backticks, prefer stdin (`echo … | gemini`) or a heredoc over inline `-p "…"`. When in doubt, ask the user to confirm the invocation before running it.
+6. Take the output into Step 4 (RECONCILE).
+
+**Never interpolate the artifact into a shell-quoted argument.** Code, markdown, and review prompts routinely contain backticks, `$(...)`, and quote characters that will either truncate the prompt or execute embedded shell. Write the full prompt to a file and pipe it through stdin.
+
+Example shapes (verify flags against your installed tool — syntax differs across implementations and versions):
+
+```bash
+# Write the adversarial prompt + ARTIFACT + CONTRACT to a temp file first.
+# Then pipe via stdin so shell metacharacters in the artifact stay inert.
+
+# Codex (read-only sandbox keeps the CLI from writing to your workspace):
+codex exec --sandbox read-only -C <repo-path> - < /tmp/doubt-prompt.md
+
+# Gemini ('--approval-mode plan' is read-only; '-p ""' triggers non-interactive
+# mode and the prompt is read from stdin):
+gemini --approval-mode plan -p "" < /tmp/doubt-prompt.md
+```
+
+A read-only sandbox is the load-bearing detail: a doubt artifact may itself contain instructions (intentional or accidental prompt injection) that the cross-model CLI would otherwise execute against your workspace.
+
+**Step 3: If the CLI is unavailable or fails**
+
+Surface the failure explicitly. Offer: run it manually, try a different tool, or skip. Do not silently fall back to single-model — the user should know cross-model didn't happen.
+
+**Step 4: If the user skips**
+
+Acknowledge the skip in the output (*"Proceeding with single-model findings only"*) and continue to RECONCILE. Skipping is fine; silent skipping is not.
+
+**Non-interactive contexts** (CI, `/loop`, autonomous-loop, scheduled runs):
+
+- Cross-model is **skipped**, and the skip must be **announced** in the output: *"Cross-model skipped: non-interactive context."*
+- **Never invoke an external CLI without explicit user authorization** — this is a load-bearing safety property.
+
+Cross-model adds cost, latency, and tool fragility. The agent surfaces the choice every cycle; the user decides whether this artifact warrants it.
+
+### Step 4: RECONCILE — Fold findings back
+
+The reviewer's output is data, not verdict. **You are still the orchestrator.** Re-read the artifact text against each finding before classifying — rubber-stamping the reviewer is the same failure mode as ignoring it.
+
+For each finding, classify in this **precedence order** (first matching class wins):
+
+1. **Contract misread** — reviewer flagged something specifically because the CONTRACT you provided was unclear or incomplete. Fix the contract first, re-classify on the next cycle.
+2. **Valid + actionable** — real issue requiring a change to the artifact. Change it, re-loop.
+3. **Valid trade-off** — issue is real but cost of fixing exceeds cost of accepting. Document the trade-off explicitly so the user sees it.
+4. **Noise** — reviewer flagged something that's actually correct under context the reviewer didn't have. Note it, move on, and ask: would adding that context to the contract have prevented the false flag?
+
+A fresh reviewer can be wrong because it lacks context. Don't defer just because it's "fresh."
+
+### Step 5: STOP — Bounded loop, not recursion
+
+Stop when:
+
+- Next iteration returns only trivial or already-considered findings, **or**
+- 3 cycles completed (escalate to user, don't grind a fourth alone), **or**
+- User explicitly says "ship it"
+
+If after 3 cycles the reviewer still surfaces substantive issues, the artifact may not be ready. Surface this to the user — three unresolved cycles is information about the artifact, not a reason to keep looping.
+
+If 3 cycles is "obviously insufficient" because the artifact is large: the artifact is too big — return to Step 2 and decompose. Do not lift the bound.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I'm confident, skip the doubt step" | Confidence correlates poorly with correctness on novel problems. Moments of certainty are exactly when blind spots hide. |
+| "Spawning a reviewer is expensive" | Debugging a wrong commit in production is more expensive. The check is bounded; the bug isn't. |
+| "The reviewer will just nitpick" | Only if unscoped. Constrain the prompt to "issues that would make this fail under the contract." |
+| "I'll do doubt at the end with `/review`" | `/review` is a final gate. Doubt-driven catches wrong directions early when course-correction is cheap. By PR time it's too late. |
+| "If I doubt every step I'll never ship" | The skill applies to non-trivial decisions, not every keystroke. Re-read "When NOT to Use." |
+| "Two opinions are always better than one" | Not when the second has less context and produces noise. Reconcile, don't defer. |
+| "The reviewer disagreed so I was wrong" | The reviewer lacks your context — disagreement is information, not verdict. Re-read the artifact, classify, then decide. |
+| "Cross-model is always better" | Cross-model catches blind spots a single model shares with itself, but it adds cost and tool fragility. Offer it every interactive doubt cycle — the user decides whether the artifact warrants it. The agent's job is to surface the choice, not to gate it. |
+| "User said yes once, so I can keep invoking the CLI" | Each invocation is its own authorization. The artifact, the prompt, and the flags change between calls — re-confirm the exact command with the user before every run. |
+
+## Red Flags
+
+- Spawning a fresh-context reviewer for a one-line rename or formatting change
+- Treating reviewer output as authoritative without re-reading the artifact text
+- Looping >3 cycles without escalating to the user
+- Prompting the reviewer with "is this good?" instead of "find issues"
+- Skipping doubt under time pressure on a high-stakes decision
+- Re-spawning fresh-context on an unchanged artifact (you'll get the same findings; you're stalling)
+- **Doubt theater (checkable signal)**: across 2 or more cycles where the reviewer surfaced substantive findings, zero findings were classified as actionable. You are validating, not doubting. Stop and escalate.
+- Doubting only after committing — that's `/review`, not doubt-driven development
+- Hardcoding an external CLI invocation without confirming with the user that the tool exists, is configured, and accepts that exact syntax
+- **Silently skipping cross-model in an interactive doubt cycle.** Even when not recommending it, the offer must be visible. Skipping is fine; silent skipping is not.
+- Falling back silently when an external CLI errors or is missing — surface the failure and let the user redirect
+- Stripping the contract from the reviewer's input
+- Passing the CLAIM to the reviewer (biases toward agreement)
+
+## Interaction with Other Skills
+
+- **`fix-review`**: complementary. `/fix-review` is post-hoc multi-model PR verdict; doubt-driven is in-flight per-decision, before a PR exists. Use both.
+- **`comprehension-gate`**: adjacent, different subject. comprehension-gate verifies the *human* understands a hard-to-reverse action before it runs; doubt-driven verifies the *agent's own reasoning* about a non-trivial artifact before it stands. Both can fire on the same decision — comprehension-gate as the human-facing gate, doubt-driven as the self-check that precedes it.
+- **`improve`**: `/improve` gives a SHIP IT / IMPROVE IT / RETHINK IT / KILL IT verdict on a finished plan or design. Doubt-driven is upstream of that — it stress-tests the reasoning while the plan is still being formed, not after.
+- **Write tests as the disproof attempt**: when the artifact makes a behavioral claim, a failing test written first (red-green-refactor) *is* the doubt step — it's a fresh, mechanical disproof attempt that doesn't need a spawned reviewer.
+- **Subagent orchestration**: this skill orchestrates from the main session only — see Loading Constraints above and `reference_agent_skill_tool_boundary` (memory) for why a subagent calling another subagent's skill doesn't work reliably.
+
+## Verification
+
+After applying doubt-driven development:
+
+- [ ] Every non-trivial decision (per the definition above) was named explicitly as a CLAIM before standing
+- [ ] At least one fresh-context review per non-trivial artifact (a failing test produced by TDD's RED step satisfies this for behavioral claims, per Interaction with Other Skills)
+- [ ] The reviewer received ARTIFACT + CONTRACT — NOT the CLAIM, NOT your reasoning
+- [ ] The reviewer's prompt was adversarial ("find issues"), not validating ("is it good")
+- [ ] Findings were classified against the artifact text (not rubber-stamped) using the precedence: contract misread / actionable / trade-off / noise
+- [ ] A stop condition was met (trivial findings, 3 cycles, or user override)
+- [ ] In interactive mode, cross-model was **explicitly offered** to the user (regardless of artifact stakes) and the response was acknowledged in the output
+- [ ] In non-interactive mode, cross-model was skipped and the skip was announced
+- [ ] Any external CLI invocation was preceded by a PATH check, a working-binary test, syntax confirmation with the user, and explicit authorization to run

--- a/.claude/skills/doubt-driven-development/SKILL.md
+++ b/.claude/skills/doubt-driven-development/SKILL.md
@@ -7,12 +7,13 @@ description: Subjects every non-trivial decision to a fresh-context adversarial 
 # Adversarial Fresh-Context Review, In-Flight
 
 Adapted from [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills)
-(MIT) — genuinely self-contained, kept close to verbatim. Complements
-`comprehension-gate` (that skill verifies the *human* understands a
-hard-to-reverse action; this one has the *agent* doubt its own non-trivial
-decisions before they stand) and `improve`/`tech-lead` (those are post-hoc
-verdicts on a finished artifact; this is in-flight, while course-correction
-is still cheap).
+(MIT) — genuinely self-contained, kept close to verbatim. Conceptually
+complements `comprehension-gate` (a related skill, not installed in this
+project — it verifies the *human* understands a hard-to-reverse action;
+this one has the *agent* doubt its own non-trivial decisions before they
+stand) and `improve`/`tech-lead` (both installed here — those give
+post-hoc verdicts on a finished artifact; this is in-flight, while
+course-correction is still cheap).
 
 ## Overview
 
@@ -114,7 +115,7 @@ CONTRACT: <paste contract>
 
 **Pass ARTIFACT + CONTRACT only. Do NOT pass the CLAIM.** Handing the reviewer your conclusion biases it toward agreement. The reviewer must independently determine whether the artifact satisfies the contract.
 
-In this library's agents (`~/wrk/common/agents/`), `tech-lead`, `static-analysis`, and `bug-fixer` start with isolated context by design and are usable here — pick whichever's domain matches the artifact.
+In this project's agents (`.claude/agents/`), `tech-lead`, `static-analysis`, and `bug-fixer` start with isolated context by design and are usable here — pick whichever's domain matches the artifact.
 
 **The adversarial prompt above takes precedence over the agent's default response shape.** Agents like `tech-lead` are written to produce balanced verdicts with both strengths and weaknesses; doubt-driven needs issues-only output. Paste the adversarial prompt verbatim into the invocation so it overrides the agent's default. If an agent's response shape can't be overridden cleanly, fall back to a generic subagent with the adversarial prompt.
 

--- a/.claude/skills/lib/rest.sh
+++ b/.claude/skills/lib/rest.sh
@@ -72,6 +72,17 @@ ollama_content() {
   printf '%s' "$1" | jq -r '.message.content // empty'
 }
 
+# Like ollama_payload_system but sets think:false (top-level field on
+# /api/chat, not inside options) and a capped num_predict. Without this,
+# reasoning-capable cloud models (deepseek, kimi, etc.) can burn their whole
+# token budget on hidden thinking and return empty content on large prompts.
+ollama_payload_system_no_think() {
+  local num_predict="${4:-4000}"
+  jq -n --arg model "$1" --arg sys "$2" --arg prompt "$3" --argjson np "$num_predict" \
+    '{model:$model, messages:[{role:"system",content:$sys},{role:"user",content:$prompt}],
+      stream:false, think:false, options:{num_predict:$np}}'
+}
+
 # ---------------------------------------------------------------------------
 # OpenRouter — /api/v1/chat/completions (OpenAI-compatible)
 # Response: { "choices": [{ "message": { "content": "..." } }] }
@@ -125,11 +136,13 @@ chat_payload_system() {
 }
 
 # Like chat_payload_system but suppresses reasoning tokens on thinking models.
-# Use for DeepSeek-family models on OpenRouter; no-op on Ollama.
+# Use for DeepSeek-family models on OpenRouter, or any reasoning-capable
+# model on Ollama (deepseek, kimi, etc. via /api/chat's top-level think field).
+# Optional 5th arg: num_predict cap, Ollama branch only (default 4000).
 chat_payload_system_no_think() {
   case "$1" in
     openrouter) openrouter_payload_system_no_think "$2" "$3" "$4" ;;
-    *)          ollama_payload_system              "$2" "$3" "$4" ;;
+    *)          ollama_payload_system_no_think      "$2" "$3" "$4" "$5" ;;
   esac
 }
 

--- a/.claude/skills/references/definition-of-done.md
+++ b/.claude/skills/references/definition-of-done.md
@@ -1,0 +1,70 @@
+# Definition of Done
+
+Adapted from [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills)
+(MIT) — stack-neutral as-is, kept close to verbatim.
+
+A standing, project-wide bar that every change must clear before it counts as done. Unlike acceptance criteria, which vary per task and answer "did we build the right thing?", the Definition of Done is the same every time and answers "is this finished to our standard?". Use it as the final gate in `backlog` (task planning), `code-generator`'s pre-flight step, and `ship`.
+
+## Definition of Done vs. Acceptance Criteria
+
+| | Acceptance Criteria | Definition of Done |
+|---|---|---|
+| Scope | Specific to one task or spec | Applies to every increment |
+| Changes | Different for each item | Fixed and reused |
+| Answers | "Did we build *this thing*?" | "Is it *ready*?" |
+| Owner | Defined when planning the task | Defined once for the project |
+| Example | "User can reset password via email link" | "Tests pass, no regressions, docs updated" |
+
+The two are complementary. A task is done only when **its** acceptance criteria are met **and** the standing Definition of Done is satisfied. Skipping either leaves work that looks finished but is not.
+
+## The Standing Checklist
+
+Apply this to every change before declaring it done.
+
+### Correctness
+- [ ] All acceptance criteria for the task are met
+- [ ] Code runs and behaves as intended, verified at runtime, not just compiled or typechecked
+- [ ] New behavior is covered by tests that fail without the change and pass with it
+- [ ] Existing tests still pass; no regressions introduced
+- [ ] Edge cases and error paths are handled, not just the happy path
+
+### Quality
+- [ ] Code reveals intent through naming and structure; no comments needed to explain *what* it does
+- [ ] No duplicated business logic
+- [ ] No dead code, debug output, or commented-out blocks left behind
+- [ ] Changes are scoped to the task; no unrelated refactors snuck in
+- [ ] Linting and formatting pass
+
+The depth behind these items lives in `fix-review` (multi-model review); this project has no dedicated `code-simplifier` agent, so complexity reduction is part of `fix-review`'s and `tech-lead`'s scope instead.
+
+### Integration
+- [ ] Change works with the rest of the system, not just in isolation
+- [ ] Database migrations, config changes, and feature flags are accounted for
+- [ ] Backward compatibility considered for any public interface or API change
+
+### Documentation
+- [ ] Public interfaces, APIs, and user-facing behavior are documented
+- [ ] Architectural decisions worth preserving are recorded (this project has no dedicated `docs-maintainer` agent — follow the `docs/architecture.md` convention directly)
+- [ ] Documentation describes the current state in timeless language, not the change history
+
+### Ship-readiness
+- [ ] Security implications reviewed for any untrusted input, auth, or data handling (see `fix-review`'s security pass)
+- [ ] Observability in place for new critical paths (logs, metrics, traces) (see `references/observability-checklist.md`)
+- [ ] Rollback path exists for anything risky (see `ship`)
+- [ ] The human has reviewed and approved before merge or deploy
+
+## How to Apply
+
+- **Per task**: confirm the Correctness and Quality sections before checking the task off.
+- **Per feature**: confirm Integration and Documentation before considering the feature complete.
+- **Per release**: the full checklist is the floor; `ship` adds the deploy-specific gates on top.
+
+Tailor the list to the project once, then reuse it unchanged. A Definition of Done that is renegotiated every sprint is not a Definition of Done.
+
+## Red Flags
+
+- "It's done, I just haven't run it yet": unverified work is not done.
+- "Tests pass" used as a synonym for done while docs, regressions, or runtime verification are skipped.
+- A different bar applied depending on deadline pressure.
+- Acceptance criteria treated as the whole bar, with no standing quality floor.
+- "Done" declared before human review on changes that need it.

--- a/.claude/skills/references/definition-of-done.md
+++ b/.claude/skills/references/definition-of-done.md
@@ -3,7 +3,7 @@
 Adapted from [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills)
 (MIT) — stack-neutral as-is, kept close to verbatim.
 
-A standing, project-wide bar that every change must clear before it counts as done. Unlike acceptance criteria, which vary per task and answer "did we build the right thing?", the Definition of Done is the same every time and answers "is this finished to our standard?". Use it as the final gate in `backlog` (task planning), `code-generator`'s pre-flight step, and `ship`.
+A standing, project-wide bar that every change must clear before it counts as done. Unlike acceptance criteria, which vary per task and answer "did we build the right thing?", the Definition of Done is the same every time and answers "is this finished to our standard?". Use it as the final gate in `code-generator`'s pre-flight step and `ship` (this project has no `backlog` task-planning skill).
 
 ## Definition of Done vs. Acceptance Criteria
 

--- a/.claude/skills/references/observability-checklist.md
+++ b/.claude/skills/references/observability-checklist.md
@@ -1,0 +1,94 @@
+# Observability Checklist
+
+Adapted from [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills)
+(MIT) — stack-neutral as-is, kept close to verbatim.
+
+Quick reference for instrumenting production code.
+
+## Table of Contents
+
+- [On-Call Questions (Start Here)](#on-call-questions-start-here)
+- [Structured Logging](#structured-logging)
+- [Metrics](#metrics)
+- [Distributed Tracing](#distributed-tracing)
+- [Alerting](#alerting)
+- [Dashboards](#dashboards)
+- [Verify the Telemetry](#verify-the-telemetry)
+- [Pre-Launch Gate](#pre-launch-gate)
+
+## On-Call Questions (Start Here)
+
+Telemetry without a question is noise. Before instrumenting anything:
+
+- [ ] 2–4 questions an on-call engineer will ask about this feature are written down
+- [ ] Every signal below maps to one of those questions
+- [ ] Each question is matched to the right signal type: metrics say **that** something is wrong, traces say **where**, logs say **why**
+
+## Structured Logging
+
+- [ ] Logs are structured (JSON) with stable event names — not free-form strings
+- [ ] Every log line carries a correlation/request ID, generated or accepted at the system boundary
+- [ ] Correlation ID is propagated on every outbound call and async boundary (HTTP headers, queue metadata)
+- [ ] Log levels are consistent: `error` = invariant broken, someone may act; `warn` = degraded but handled; `info` = significant business event; `debug` = off in production
+- [ ] No secrets, tokens, passwords, or unredacted PII in any log line (hard rule, checked by `fix-review`'s security pass)
+- [ ] Fields are allowlisted — no whole request/response bodies, no auth headers
+- [ ] External service calls logged with metadata only: endpoint, status, latency, attempt count, sanitized identifiers
+- [ ] Actual log output spot-checked: structured fields, not `[object Object]`
+
+## Metrics
+
+- [ ] **RED** instrumented for every endpoint and every external dependency: Rate, Errors, Duration
+- [ ] **USE** instrumented for every resource (queues, pools, hosts): Utilization, Saturation, Errors
+- [ ] Latency is a histogram; p50/p95/p99 queryable — never an average
+- [ ] All labels come from small, fixed sets (route template, status class, provider name)
+- [ ] No unbounded label values: no user IDs, tenant IDs, emails, raw URLs, request IDs, or error message text
+- [ ] Status codes grouped by class (`5xx`, not `503`)
+- [ ] Queue depth and processing duration tracked for every worker/queue
+
+## Distributed Tracing
+
+- [ ] OpenTelemetry (or equivalent) initialized at service startup, before other imports
+- [ ] Auto-instrumentation enabled for HTTP, gRPC, and DB clients
+- [ ] Trace context propagated on every outbound call (W3C `traceparent`/`tracestate`) and extracted from every inbound request
+- [ ] Context survives async boundaries — queue messages carry trace metadata
+- [ ] Manual spans only around meaningful internal units of work, with the attributes on-call will filter by
+- [ ] No secrets or PII as span attributes
+- [ ] Head-based sampling at a low default rate; 100% of errors kept if tail sampling is available
+
+## Alerting
+
+- [ ] Every alert is symptom-based (error rate, p99 latency, queue age) — causes (CPU, disk, restarts) go to dashboards, not pagers
+- [ ] Every alert is actionable; "ignore it, it self-heals" alerts are deleted
+- [ ] Every alert links to a runbook — minimum three lines: what it means, first query to run, escalation path
+- [ ] Thresholds and durations justified by an SLO or historical data, not guesses
+- [ ] Two severities only: **page** (user-facing, act now) and **ticket** (degradation, act this week)
+- [ ] Each new alert test-fired once: it reached the right channel and the runbook link works
+- [ ] No alerts that fire daily and get acknowledged without action
+
+## Dashboards
+
+- [ ] Service health dashboard exists: error rate, latency p99, traffic, saturation
+- [ ] Dependency health panel shows per-service error rates and latency
+- [ ] Dashboard answers the on-call questions from the top of this checklist — not "everything except the answer"
+- [ ] Default time range is sensible (1h–6h, not 30d)
+
+## Verify the Telemetry
+
+Instrumentation is code; it can be wrong:
+
+- [ ] Forced an error in staging → found it in the logs by correlation ID
+- [ ] Sent test traffic → metric series appear with expected labels and sane values
+- [ ] Followed one request end-to-end in the tracing UI → no broken spans
+- [ ] An induced failure was diagnosed from telemetry alone, without reading the source
+
+## Pre-Launch Gate
+
+Before a feature ships to production, all of the following are true:
+
+- [ ] Structured logs flowing to the log aggregator
+- [ ] RED metrics visible in dashboards for every new endpoint and dependency
+- [ ] At least one symptom-based alert configured, with runbook, test-fired
+- [ ] A request can be traced across every service it touches
+- [ ] On-call knows where the runbooks are
+
+For launch-day monitoring sequence and rollback triggers, see `ship`.

--- a/.claude/skills/self-learn/SKILL.md
+++ b/.claude/skills/self-learn/SKILL.md
@@ -1,0 +1,546 @@
+---
+name: self-learn
+description: "Self-learning system — log mistakes/wins, run retrospectives, promote patterns to hard rules, and coach on workflow quality. Usage: /self-learn [log|retro|status|init|tips]"
+---
+
+# Skill: /self-learn
+# Portable Self-Learning System
+
+---
+
+## OVERVIEW
+
+A self-learning loop that captures mistakes and wins, promotes recurring patterns
+to hard rules, runs periodic retrospectives, and provides proactive workflow coaching.
+
+```
+/self-learn              → show status (counts, recent entries, pending promotions)
+/self-learn log          → interactive: ask what happened, classify, and log it
+/self-learn retro        → run a full retrospective analysis
+/self-learn init         → initialize _patterns/ and _knowledge-base/ for a new project
+/self-learn tips         → analyze recent patterns and give personalized workflow tips
+```
+
+The system gets smarter with every interaction. Log from day one.
+
+---
+
+## STEP 0: Resolve Command
+
+Parse the argument:
+- No argument or `status` → jump to **STATUS**
+- `log` → jump to **LOG**
+- `retro` → jump to **RETRO**
+- `init` → jump to **INIT**
+- `tips` → jump to **TIPS**
+
+---
+
+## INIT — Bootstrap for New Project
+
+Check if the directories and files exist. Create anything missing:
+
+```
+_patterns/
+  mistakes.jsonl          # one JSON object per line
+  wins.jsonl              # one JSON object per line
+  cross-project.md        # patterns that apply across projects/modules
+  anti-patterns.md        # approaches that keep failing — stop trying them
+_knowledge-base/
+  decisions.md            # Architecture Decision Records
+  api-docs/               # per-API gotcha files (e.g. steam-connect.md, supabase.md)
+```
+
+For each file, create it only if it doesn't exist. Never overwrite existing data.
+
+Also check for `.claude/skills/self-learn/config` — if absent, do not create it
+(it's optional; the user creates it manually to set `project_name:`).
+
+**`mistakes.jsonl`** — create empty (0 bytes).
+**`wins.jsonl`** — create empty (0 bytes).
+
+**`cross-project.md`** — create with header:
+```markdown
+# Cross-Project Patterns
+
+Patterns proven in 2+ areas/projects. Promoted automatically by /self-learn retro.
+
+---
+```
+
+**`anti-patterns.md`** — create with header:
+```markdown
+# Anti-Patterns
+
+Approaches that keep failing. When you're about to try one of these, stop and find an alternative.
+
+---
+```
+
+**`_knowledge-base/decisions.md`** — create with header:
+```markdown
+# Architecture Decision Records
+
+| Date | Decision | Context | Alternatives Considered |
+|------|----------|---------|------------------------|
+```
+
+After creating, print:
+> "Self-learning initialized. Directories and pattern files are ready.
+> Start logging with `/self-learn log` after any significant task."
+
+---
+
+## LOG — Capture a Mistake or Win
+
+### Step 1: Determine type
+
+Ask the user:
+> "What happened? I'll classify it as a **mistake** (something went wrong or was corrected)
+> or a **win** (something worked well, was confirmed, or saved time).
+>
+> Describe it briefly, or say 'mistake' or 'win' to start from the category."
+
+If the user describes the event, classify it yourself:
+- User correction, failed approach, wrong assumption, redo → **mistake**
+- Confirmed approach, clever solution, time saved, bug caught early → **win**
+
+Confirm the classification before logging:
+> "I'd classify this as a [mistake/win]. Sound right?"
+
+### Step 2: Build the entry
+
+**For a mistake**, gather these fields (ask for any you can't infer from context):
+
+Project name resolution order: `.claude/skills/self-learn/config` (key `project_name:`)
+→ basename of current working directory → ask the user.
+
+```json
+{
+  "date": "YYYY-MM-DD",
+  "project": "<config file → working directory name → ask>",
+  "task": "<what was being done>",
+  "mistake": "<what went wrong>",
+  "resolution": "<how it was fixed>",
+  "pattern": "<generalizable lesson — one sentence>",
+  "severity": "low|medium|high",
+  "category": "<see category list below>",
+  "had_verification": true|false,
+  "session_hygiene": "<optional: kitchen_sink|correction_spiral|context_overload|null>"
+}
+```
+
+**Mistake categories** (classify every mistake into one):
+
+| Category | When to use |
+|----------|------------|
+| `api_error` | Wrong endpoint, format, auth, or field name |
+| `wrong_assumption` | Guessed instead of verified (module name, flag, behavior) |
+| `missed_context` | Didn't read docs, existing code, or CLAUDE.md |
+| `didnt_ask` | Acted on ambiguity instead of clarifying |
+| `prompt_quality` | Vague or under-specified prompt led to wrong output |
+| `context_waste` | Didn't `/clear`, kitchen-sink session, or context overload |
+| `skipped_planning` | Jumped to code without plan mode on a multi-file task |
+| `tooling_error` | Wrong tool, flag, command, or config |
+| `other` | Doesn't fit above categories |
+
+**Session hygiene flags** (optional — set when relevant):
+
+| Flag | When to use |
+|------|------------|
+| `kitchen_sink` | Mixed unrelated tasks in one session without `/clear` |
+| `correction_spiral` | 3+ corrections on the same issue in one session |
+| `context_overload` | Context window filled with irrelevant files/output |
+| `infinite_exploration` | Unbounded investigation that read too many files |
+
+Severity guide:
+
+| Severity | Definition |
+|----------|-----------|
+| **high** | Production impact, data loss, or significant rework (>30 min wasted) |
+| **medium** | Multiple retries, wasted significant time, wrong assumptions that cascaded |
+| **low** | Minor inconvenience, caught quickly, small rework |
+
+**For a win**, gather these fields:
+
+```json
+{
+  "date": "YYYY-MM-DD",
+  "project": "<config file → working directory name → ask>",
+  "task": "<what was being done>",
+  "win": "<what worked well>",
+  "pattern": "<reusable lesson — one sentence>",
+  "reusable_in": "<where else this applies>",
+  "had_verification": true|false,
+  "used_plan_mode": true|false,
+  "delegation": "subagent|manual|none",
+  "decomposed": true|false
+}
+```
+
+**Field explanations for new fields:**
+- `had_verification` — Did the task have tests, linter checks, screenshots, or expected outputs for self-checking? (The #1 best practice from Anthropic: "the single highest-leverage thing you can do")
+- `used_plan_mode` — Was plan mode / explore-first approach used before implementation?
+- `delegation` — Was work delegated to subagents to protect main context?
+- `decomposed` — Was the work broken into phases (search → plan → execute → verify) rather than a monolithic prompt?
+
+### Step 3: Append to file
+
+Append the JSON object as a single line to the appropriate file:
+- Mistakes → `_patterns/mistakes.jsonl`
+- Wins → `_patterns/wins.jsonl`
+
+Use the Write tool to append (read existing content, add new line, write back).
+Never overwrite — always append.
+
+### Step 4: Check for promotion triggers
+
+After logging, immediately check:
+
+**For mistakes:**
+1. Read all entries in `mistakes.jsonl`
+2. Extract the `pattern` field from each
+3. Group similar patterns (same API, same type of error, same root cause)
+4. If any pattern appears **2+ times** → trigger promotion:
+
+> "This mistake has occurred [N] times. Promoting to a hard rule in CLAUDE.md:
+>
+> - **[RULE NAME]** *(promoted YYYY-MM-DD — [N] mistakes)*: [instruction].
+>   Never [bad approach] — always [correct approach]. Verify by [verification step]."
+
+Then actually add the rule to the project's CLAUDE.md under a `## Self-Learning Hard Rules`
+section (create the section if it doesn't exist). Add it at the end of that section.
+
+**For wins:**
+1. Read the `reusable_in` field
+2. If it mentions 2+ distinct areas or "all projects" → add to `_patterns/cross-project.md`
+
+### Step 5: Confirm
+
+Print the logged entry and any promotions:
+> "Logged [mistake/win]. [N] total [mistakes/wins] tracked.
+> [Promoted to hard rule in CLAUDE.md. / No promotion triggered.]"
+
+---
+
+## STATUS — Dashboard
+
+Read the pattern files and display a summary:
+
+```
+## Self-Learning Status
+
+### Pattern Store
+- Mistakes: [N] logged ([H] high, [M] medium, [L] low)
+- Wins: [N] logged
+- Cross-project patterns: [N]
+- Anti-patterns: [N]
+- Hard rules promoted: [N]
+
+### Verification Rate
+- Tasks with verification: [N]% (wins: [X]%, mistakes: [Y]%)
+- Insight: [correlation observation]
+
+### Mistake Categories
+| Category | Count | % |
+|----------|-------|---|
+| [category] | [N] | [%] |
+
+### Session Hygiene
+- Kitchen sink sessions: [N]
+- Correction spirals: [N]
+- Context overloads: [N]
+
+### Recent (last 5)
+| Date | Type | Summary |
+|------|------|---------|
+| ... | mistake/win | pattern field |
+
+### Pending Promotions
+[List any patterns that have occurred 2+ times but haven't been promoted yet]
+
+### Last Retrospective
+[Date of last retro, or "Never — run /self-learn retro"]
+```
+
+---
+
+## RETRO — Full Retrospective
+
+### Step 1: Gather data
+
+Read all of:
+- `_patterns/mistakes.jsonl` — parse each line as JSON
+- `_patterns/wins.jsonl` — parse each line as JSON
+- `_patterns/cross-project.md`
+- `_patterns/anti-patterns.md`
+- The project's CLAUDE.md (for existing hard rules)
+
+If `mistakes.jsonl` + `wins.jsonl` have fewer than 3 entries total:
+> "Not enough data for a meaningful retrospective. Log more interactions first.
+> Current count: [N] mistakes, [M] wins."
+Stop.
+
+### Step 2: Analyze
+
+**Group mistakes by category:**
+Count entries per `category` field. If entries lack the field, infer from description.
+
+**Identify recurring patterns:**
+- Any mistake pattern occurring 2+ times → flag for hard rule promotion
+- Any mistake pattern occurring 3+ times → flag as anti-pattern
+
+**Verification correlation:**
+- Calculate win rate for tasks WITH verification vs WITHOUT
+- If tasks without verification fail 2x+ more → flag for hard rule
+
+**Plan mode correlation:**
+- Calculate success rate for tasks that used plan mode vs didn't
+- If skipping planning correlates with failures → flag for hard rule
+
+**Session hygiene analysis:**
+- Count each session_hygiene flag across all mistakes
+- If any flag appears 3+ times → promote to anti-pattern
+
+**Delegation analysis:**
+- Compare success rate of tasks using subagent delegation vs none
+- If delegation correlates with fewer context-related failures → flag as win pattern
+
+**Decomposition analysis:**
+- Compare success rate of decomposed tasks (phased) vs monolithic prompts
+- If monolithic tasks fail more → promote decomposition as a best practice
+
+**Identify cross-project wins:**
+- Any win with `reusable_in` mentioning 2+ areas
+
+**Check for stale patterns:**
+- Any hard rule in CLAUDE.md that hasn't been triggered in 30+ days
+- Any anti-pattern that might no longer apply (tech/API changed)
+
+### Step 3: Generate report
+
+```markdown
+## Retrospective Report — {date}
+
+### Stats
+- Period: {earliest entry date} → {latest entry date}
+- Mistakes: {N} ({high} high, {medium} medium, {low} low)
+- Wins: {N}
+
+### Verification Impact
+- Tasks WITH verification: {N}% success rate
+- Tasks WITHOUT verification: {N}% success rate
+- Verdict: {observation}
+
+### Planning Impact
+- Tasks WITH plan mode: {N}% success rate
+- Tasks WITHOUT plan mode: {N}% success rate
+- Verdict: {observation}
+
+### Top Mistake Categories
+| Category | Count | Trend |
+|----------|-------|-------|
+| {category} | {N} | ↑ ↓ → |
+
+### Session Hygiene Issues
+- Kitchen sink sessions: {N} → {recommendation}
+- Correction spirals: {N} → {recommendation}
+- Context overloads: {N} → {recommendation}
+
+### Recurring Mistakes (Need Hard Rules)
+{For each pattern occurring 2+ times:}
+- **{pattern}** — occurred {N} times (dates: {list})
+  → PROMOTE to CLAUDE.md as hard rule
+
+### Anti-Patterns to Stop
+{For each pattern occurring 3+ times:}
+- **{pattern}** — tried {N} times, failed every time
+  → Add to anti-patterns.md
+
+### Wins Worth Replicating
+{For each win with broad applicability:}
+- **{pattern}** — applicable to: {reusable_in}
+
+### Cross-Project Opportunities
+{Patterns from one area that could solve problems in another}
+
+### Knowledge Base Updates
+{New API gotchas, new decisions to document}
+
+### Stale Patterns
+{Hard rules or anti-patterns that may no longer apply}
+
+### Action Items
+- [ ] {specific update to make}
+```
+
+### Step 4: Auto-apply
+
+After generating the report, apply the changes:
+
+1. **Promote recurring mistakes** to CLAUDE.md (under `## Self-Learning Hard Rules`)
+2. **Add new anti-patterns** to `_patterns/anti-patterns.md`
+3. **Add cross-project patterns** to `_patterns/cross-project.md`
+4. **Flag stale patterns** for user review (don't auto-remove)
+
+### Step 5: Confirm
+
+Print the report and list what was changed:
+> "Retrospective complete. Applied:
+> - [N] new hard rules promoted to CLAUDE.md
+> - [N] new anti-patterns logged
+> - [N] cross-project patterns updated
+> - [N] stale patterns flagged for review
+>
+> Anything surprise you? Anything I should weight differently?"
+
+---
+
+## TIPS — Personalized Workflow Coaching
+
+Analyze the pattern store and give actionable, personalized tips based on the user's
+actual tracked data. These tips come from official Claude Code best practices,
+real production patterns, and the user's own history.
+
+### Step 1: Read pattern data
+
+Read `_patterns/mistakes.jsonl` and `_patterns/wins.jsonl`.
+
+### Step 2: Analyze and generate tips
+
+For each category below, check if the user's data suggests the tip is relevant.
+Only show tips that are backed by the user's own patterns — don't dump generic advice.
+
+**Verification tips** (if `had_verification` is false on 50%+ of mistakes):
+> "**Add verification to your workflow.** {N}% of your mistakes happened on tasks
+> without verification (tests, linter checks, screenshots). Tasks WITH verification
+> had a {X}% success rate. Try: include `run the tests after implementing` in your
+> prompts, or add a PostToolUse hook that auto-runs your formatter."
+
+**Plan mode tips** (if `skipped_planning` category has 2+ entries):
+> "**Plan before multi-file changes.** You've had {N} mistakes from jumping straight
+> to code. Try: press Shift+Tab for plan mode, explore the code first, ask Claude
+> to create a plan, then switch to normal mode to implement."
+
+**Context hygiene tips** (if `context_waste`/`session_hygiene` flags appear):
+> "**Use /clear more aggressively.** {N} mistakes were context-related.
+> Run `/clear` between unrelated tasks. If you've corrected Claude 2+ times on
+> the same issue, `/clear` and rewrite a better prompt — a clean session with a
+> better prompt almost always outperforms accumulated corrections."
+
+**Delegation tips** (if context-related mistakes exist but few subagent wins):
+> "**Delegate research to subagents.** When Claude reads many files to investigate
+> something, it fills your context. Try: `use subagents to investigate X` — they
+> explore in a separate context and report back summaries."
+
+**Prompt quality tips** (if `prompt_quality` category has entries):
+> "**Be more specific in your prompts.** {N} mistakes came from vague instructions.
+> Instead of `fix the login bug`, try: `users report login fails after session timeout.
+> Check the auth flow in src/auth/, especially token refresh. Write a failing test
+> that reproduces the issue, then fix it.`"
+
+**API integration tips** (if `api_error` category has entries):
+> "**Test APIs with minimal payloads first.** {N} API mistakes logged. Before
+> building the full integration, send the simplest possible request and confirm
+> the format, field names, and auth work. Document gotchas immediately in
+> `_knowledge-base/api-docs/`."
+
+**Decomposition tips** (if mistakes involve large multi-step tasks):
+> "**Break complex work into phases.** Instead of one massive prompt like
+> 'refactor this entire module, update tests, and fix docs,' decompose into:
+> search phase → plan phase → execute phase → verify phase.
+> The architecture is designed for decomposition, not monolithic prompts."
+
+**Command utilization tips** (if pattern data shows underuse of slash commands):
+> "**You're underusing the command surface.** Claude Code has ~85 slash commands.
+> Key ones to adopt: `/compact` (compress context, save tokens), `/plan` (map
+> work before executing), `/review` and `/security-review` (structured code
+> review), `/cost` (track spending), `/resume` (pick up where you left off).
+> Most users know 5 commands — learn 15 and your workflow transforms."
+
+**Permission tips** (if mistakes involve repeated permission interruptions or slow workflows):
+> "**Configure wildcard permissions for recurring workflows.** Instead of
+> approving every git command, set `Bash(git *)` as always-allow. For file
+> edits in your source: `Edit(src/*)`. Set these in `.claude/settings.json`
+> once and stop babysitting every action."
+
+**Operator mindset tips** (always show if < 10 total entries — new users):
+> "**Think like an operator, not a chatbot user.** The biggest gap between
+> average and top users: top users design a better operating environment
+> (CLAUDE.md, permissions, hooks, MCP, skills) rather than just writing
+> better prompts. Prompting is one lever. Environment design is the
+> multiplier. Invest in your CLAUDE.md, permission rules, and connected tools."
+
+**Winning patterns** (always show top 3 wins by reusability):
+> "**Your best patterns:**
+> 1. {win pattern} — used in {reusable_in}
+> 2. {win pattern} — used in {reusable_in}
+> 3. {win pattern} — used in {reusable_in}"
+
+### Step 3: Summary score
+
+Calculate a simple "learning score":
+
+```
+Score = (wins / (wins + mistakes)) * 100
+
+Trend: compare last 7 entries vs previous 7 entries
+```
+
+> "**Learning score: {N}%** ({trend: improving/stable/declining})
+> {observation about what's driving the trend}"
+
+---
+
+## ALWAYS-ON BEHAVIORS
+
+These behaviors run automatically, not just when /self-learn is invoked.
+They should be integrated into the project's CLAUDE.md as reminders.
+
+### Before Any Task
+1. Check `_patterns/mistakes.jsonl` — have I made a related mistake before?
+2. Check `_patterns/anti-patterns.md` — am I about to try something that keeps failing?
+3. Check `_patterns/wins.jsonl` — is there a proven approach for this?
+4. If the task involves an API, check `_knowledge-base/api-docs/` for known gotchas
+5. If the task touches multiple files, suggest plan mode first
+
+### During Any Task
+- When unsure about an API's behavior → test with minimal payload first
+- When a function/module might not exist → verify before using it
+- When you spot a potential issue unrelated to the current task → flag it:
+  "Heads up: I noticed [X]"
+- When context is getting long → suggest `/clear` or subagent delegation
+
+### After Any Significant Task
+1. Did anything fail that I had to retry? → Offer to log mistake
+2. Did I find a clever solution? → Offer to log win
+3. Did the user correct me? → Log mistake immediately (don't ask)
+4. Did the user confirm a non-obvious approach? → Log win (easy to miss — watch for it)
+5. Did the task have verification? → Note for correlation tracking
+
+### On Session Start
+1. Check recently modified pattern files for context
+2. If recent high-severity mistakes exist, mention them:
+   > "Heads up: recent issue logged — [pattern]. I'll watch for this."
+
+### Session Hygiene Monitoring
+- If the conversation has mixed 3+ unrelated topics → suggest `/clear`
+- If the same correction has been made 2+ times → suggest `/clear` and a fresh prompt
+- If file reads exceed 20 in one investigation → suggest subagent delegation
+
+---
+
+## RULES
+
+1. **Never overwrite pattern files** — always append. Data is sacred.
+2. **Never delete entries** — mark as resolved/stale instead.
+3. **Always confirm classification** before logging — "I'd classify this as a [X]. Sound right?"
+4. **Log confirmations, not just corrections** — if you only track mistakes, you become overly cautious and drift from validated approaches.
+5. **Severity is honest** — don't downplay to avoid looking bad. High means high.
+6. **Promotion is automatic** — 2+ occurrences = hard rule. Don't wait for the user to ask.
+7. **Retrospectives are non-judgmental** — they analyze patterns, not blame.
+8. **Cross-project patterns require evidence** — at least 2 distinct contexts confirming the pattern.
+9. **Anti-patterns are conclusive** — 3+ failures of the same approach. Not just "didn't work once."
+10. **Stale patterns get flagged, not auto-removed** — the user decides if they're still relevant.
+11. **Tips are data-driven** — only show tips backed by the user's own pattern data, not generic advice.
+12. **New fields are optional** — `category`, `had_verification`, `session_hygiene`, `used_plan_mode`, and `delegation` enrich analysis but should never block logging. If unknown, omit the field.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -243,8 +243,12 @@ On failure: warn, ask user to close {ISSUE_URL} manually.
 
 Skip silently if `.claude/skills/self-learn/` doesn't exist in this project.
 
-Log one entry via `/self-learn log`, classified by what actually happened
-this run:
+`/self-learn log`'s Step 1 is written for interactive human invocation
+("Ask the user: what happened?") — `/ship` runs this step itself, without
+a human in the loop, so do **not** wait for input. Classify and log
+directly using what you already observed during this run, following the
+self-learn LOG step's own field schema and "if the user describes the
+event, classify it yourself" allowance:
 - Smooth run, zero `/fix-review` escalations → **win**
 - `/fix-review` caught something that should have been prevented earlier
   (wrong pattern, missed edge case, convention violation) → **mistake**

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -22,6 +22,7 @@ description: "session-indexer ship pipeline: issue → implement → review → 
   → merge PR             (/ship owns the merge)
   → post comment         (summary: what changed, PR link)
   → close issue
+  → log to /self-learn (if installed)
   → final report
 ```
 
@@ -238,7 +239,24 @@ On failure: warn, ask user to close {ISSUE_URL} manually.
 
 ---
 
-## STEP 6: Final Report
+## STEP 6: Log to /self-learn (if installed)
+
+Skip silently if `.claude/skills/self-learn/` doesn't exist in this project.
+
+Log one entry via `/self-learn log`, classified by what actually happened
+this run:
+- Smooth run, zero `/fix-review` escalations → **win**
+- `/fix-review` caught something that should have been prevented earlier
+  (wrong pattern, missed edge case, convention violation) → **mistake**
+- STEP 0.5 ambiguity analysis surfaced a decision that would otherwise have
+  produced a wrong implementation → **win**
+
+If the log call fails or `/self-learn` isn't installed, don't block the
+pipeline on it — note it in the final report's Warnings and move on.
+
+---
+
+## STEP 7: Final Report
 
 ```
 ## /ship complete — #{ISSUE_NUMBER} {ISSUE_TITLE}


### PR DESCRIPTION
## Summary

Per `~/wrk/common/tmp/session-indexer-sync-2026-07-12.md`, synced fixes and new skills from the shared library, applied item-by-item with explicit confirmation each time:

1. **`lib/rest.sh`** — replaced with the library's fixed version. `chat_payload_system_no_think()` fell through to a plain `ollama_payload_system` call on the Ollama branch (a no-op — `think: false` was never actually set for Ollama reasoning models). Currently dormant in this project (`fix-review/SKILL.md` builds its Ollama payload inline, doesn't call this function), but fixed for correctness and any future caller. No local customizations lost.
2. **`agents/code-generator.md`** — added `Agent` to `tools:`. STEP 7 launches `tech-lead` as a nested subagent spawn; without `Agent` in the allowlist, Claude Code ≥v2.1.172's nested-spawn permission requirement silently no-ops the call — tech-lead post-implementation review was never actually running.
3. **`skills/self-learn/`** — installed. Wired into `ship/SKILL.md` as STEP 6 (inserted by hand, not a blind overwrite — this project's `ship/SKILL.md` has real customizations: repo name, agent name, lint/test commands).
4. **`skills/doubt-driven-development/`** — installed as-is (references `tech-lead`/`static-analysis`/`bug-fixer`, all present here already).
5. **`skills/references/`** — installed `definition-of-done.md` + `observability-checklist.md`, adjusted two references to agents this project doesn't have (`code-simplifier`, `docs-maintainer`) to point at what actually exists.

Docs/`.claude/`-only diff — no Go source touched.

## Test plan

- [x] `bash -n .claude/skills/lib/rest.sh` — syntax OK
- [x] Diffed library vs project copies before overwriting to confirm no local customizations would be lost
- [ ] Next `/ship` run — confirm a `_patterns/*.jsonl` entry appears (self-learn wiring)
- [ ] Next `code-generator` run reaching STEP 7 — confirm tech-lead review actually executes now

🤖 Generated with [Claude Code](https://claude.com/claude-code)