### PR TITLE
chore: gitignore sqlite WAL sidecar files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ vendor/
 # Session recall
 .claude/session-log.md
 .claude/sessions.db
+.claude/sessions.db-shm
+.claude/sessions.db-wal
 
 # Claude Code local-only settings — never commit (per-machine hook wiring)
 .claude/settings.local.json


### PR DESCRIPTION
## Summary

- `.claude/sessions.db-shm` and `.claude/sessions.db-wal` (SQLite WAL-mode sidecars) were showing as untracked — same per-machine local state as `sessions.db`, just missed when that gitignore entry was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)