### PR TITLE
chore: sync fixes from ~/wrk/common skill library, part 2

### DIFF
--- a/.claude/skills/find-bugs/SKILL.md
+++ b/.claude/skills/find-bugs/SKILL.md
@@ -1,87 +1,161 @@
 ---
 name: find-bugs
-description: "Find bugs, security vulnerabilities, and code quality issues in branch changes. Report-only — no code changes. Usage: /find-bugs [topic]"
+description: "Read-only bug audit of the current branch vs a base ref. Dispatches subagents per stack (Go, JS/TS, etc.), consolidates findings, produces a prioritized report. Does not fix. Usage: /find-bugs [base-ref]"
 ---
 
 # Skill: /find-bugs
-# Code Review — Bug & Vulnerability Hunt
+# Bug Audit — Read-Only
 
-Report only. Do not make changes.
-
----
-
-## Phase 1 — Input Gathering
-
-1. Get the full diff: `git diff $(git merge-base main HEAD)...HEAD`
-2. If truncated, read each changed file individually until every changed line is seen.
-3. List all modified files before proceeding. Do not skip any.
+Audit the current branch for bugs without touching code. Produces a
+prioritized report; user decides what to fix.
 
 ---
 
-## Phase 2 — Attack Surface Mapping
+## Steps
 
-For each changed file, identify and list:
+### Step 1 — Determine scope
 
-- All **user-controlled inputs** (URL params, request bodies, query strings, form fields)
-- All **external calls** — are errors checked? are timeouts set? are responses closed/consumed?
-- All **state mutations** — shared state modified without locks? mutation visible to other goroutines/threads?
-- All **file/path operations** — paths constructed from user data?
-- All **resource allocations** — unbounded loops or allocations on user-supplied sizes?
-- All **silent failures** — errors swallowed, empty fallbacks, missing nil/null checks?
+```bash
+BASE="${1:-main}"
 
----
+# If on a feature branch: diff vs base
+git rev-parse --verify "$BASE" 2>/dev/null && \
+  DIFF=$(git diff "$BASE"...HEAD) || \
+  DIFF=$(git diff HEAD~10...HEAD)
 
-## Phase 3 — Security Checklist
+# Fallback: on main with no base arg → recent commits
+if [[ -z "$DIFF" ]]; then
+  DIFF=$(git log --since='2 weeks ago' -p --no-merges)
+fi
 
-Check every item against every changed file:
-
-- [ ] **Injection** — user input reaching SQL queries, shell commands, file paths, template strings?
-- [ ] **Hardcoded secrets** — API keys, passwords, tokens in changed code?
-- [ ] **Auth bypass** — can authentication or authorization checks be skipped?
-- [ ] **Information disclosure** — error messages returning stack traces, internal paths, or sensitive data?
-- [ ] **Path traversal** — file paths constructed from user-supplied strings without sanitization?
-- [ ] **Request body limits** — is unbounded user-supplied data size possible?
-- [ ] **Missing null/nil checks** — pointer dereference or null access on values that could be absent?
-- [ ] **Race conditions** — shared mutable state accessed from concurrent paths?
-- [ ] **Dependency confusion** — any new unreviewed packages introduced?
-
-> **Stack-specific items:** run `/generate-find-bugs` to add language/framework checklists
-> (Go: goroutine leaks, context propagation; JS: XSS, prototype pollution; etc.)
-
----
-
-## Phase 4 — Verification
-
-For each potential issue:
-- Check if it is already guarded elsewhere in the changed code.
-- Read at least 10 lines of surrounding context to confirm the issue is real.
-- Only report issues you can substantiate with evidence from the diff.
-
----
-
-## Phase 5 — Pre-Conclusion Audit
-
-Before finalizing:
-1. List every file reviewed — confirm each was read completely.
-2. List every checklist item: issue found, or confirmed clean.
-3. List anything you could NOT fully verify and why.
-
----
-
-## Output Format
-
-**Priority:** security vulnerabilities > correctness bugs > performance > code quality
-
-**Skip:** style, formatting, naming preferences
-
-For each issue:
-
-```
-**File:Line** — brief description
-Severity  : Critical / High / Medium / Low
-Problem   : what's wrong
-Evidence  : why this is real (no existing guard, language semantics confirm it)
-Fix       : concrete suggestion
+echo "Auditing $(git rev-parse --abbrev-ref HEAD) vs $BASE"
+echo "Diff size: $(echo "$DIFF" | wc -l) lines"
 ```
 
-If nothing significant: say so — don't invent issues.
+If diff > 2000 lines: warn and ask if user wants to narrow scope
+(specific files or commits) before proceeding.
+
+### Step 2 — Read project context
+
+```bash
+head -100 CLAUDE.md 2>/dev/null
+cat .claude/context-essentials.md 2>/dev/null
+
+# Detect stack
+cat go.mod 2>/dev/null | head -3
+cat package.json 2>/dev/null | python3 -c "
+import sys,json; d=json.load(sys.stdin)
+print({**d.get('dependencies',{}), **d.get('devDependencies',{})}.keys())
+" 2>/dev/null
+
+# Changed files by type
+git diff "$BASE"...HEAD --name-only | sort
+```
+
+### Step 3 — Dispatch stack-aware subagents
+
+Dispatch **in parallel** based on detected stack. Each subagent gets:
+- The full diff
+- Project context (CLAUDE.md / context-essentials.md excerpt)
+- Stack-specific checklist (below)
+
+**Always dispatch — Generic bug finder:**
+
+Checklist:
+- Null/nil dereference on unchecked return values
+- Resource leaks (files, connections, goroutines not closed/cancelled)
+- Unhandled errors silently discarded (`_ = err`, bare `catch {}`)
+- Off-by-one in loops, slice bounds, index arithmetic
+- Race conditions: shared mutable state accessed from goroutines/async
+- Incorrect error propagation (wrapping lost, status code swallowed)
+- Context not propagated into blocking calls
+- Missing timeout on external calls (HTTP, DB, queue)
+
+**If `.go` files changed — Go reviewer:**
+
+Additional checklist:
+- `defer f.Close()` missing after open (cursor/file leak)
+- `sync.Mutex` copied by value
+- `go func()` capturing loop variable by reference (pre-Go 1.22)
+- `http.Response.Body` not closed
+- `context.WithCancel` leak (cancel not called on all paths)
+- Integer overflow in slice/index math
+- `iota` misuse in const blocks
+
+**If `.ts` / `.tsx` / `.js` files changed — JS/TS reviewer:**
+
+Additional checklist:
+- `await` missing on async calls (fire-and-forget)
+- Unhandled promise rejection
+- `useEffect` missing dependency array or stale closure
+- `JSON.parse` without try/catch
+- Type assertion `as X` hiding runtime mismatch
+- `undefined` access on optional chaining result used as non-optional
+
+**If DB/ORM files changed (any stack) — DB reviewer:**
+
+Additional checklist:
+- Query result not closed / cursor leak
+- Missing transaction rollback on error path
+- N+1 query pattern introduced
+- Unique constraint not enforced at app level (only in migration)
+- Index missing for new filter/sort introduced in diff
+
+### Step 4 — Consolidate
+
+Merge all subagent reports:
+- Deduplicate by `(file, line)` — keep highest severity, merge bodies
+- Remove findings already caught by `make lint` / linter output
+- Remove "consider adding X" without concrete evidence in the diff
+
+### Step 5 — Report
+
+```markdown
+# Bug audit — <branch> vs <base> — <date>
+
+## Critical — block merge
+- `file.go:42` **nil deref**: `resp.Body` read before nil check after `http.Get` error path.
+  Fix: check `err != nil` before using `resp`.
+
+## High
+- ...
+
+## Medium
+- ...
+
+## Low / nits
+- ...
+
+---
+Findings: <N> total (<critical> critical, <high> high, <medium> medium, <low> low)
+```
+
+Save to `/tmp/<project>-bugs-<short-sha>.md` and print inline.
+
+Final message:
+> "<N> findings. Address with Edit or a dedicated fix subagent."
+
+---
+
+## Constraints
+
+- **Read-only.** No edits, no commits, no `git checkout`.
+- **Cite file:line** for every finding — no location = skip it.
+- **Differentiate certainty**: "definite bug" vs "potential hazard" vs "worth checking".
+- Severity guide:
+
+  | Level | Definition |
+  |-------|-----------|
+  | Critical | Definite crash, data corruption, or security hole in the diff |
+  | High | Likely bug under realistic conditions; resource leak |
+  | Medium | Potential bug; depends on caller contract not visible in diff |
+  | Low | Minor hazard, defensive improvement, nit |
+
+---
+
+## Anti-patterns
+
+- ❌ Generic "consider adding error handling" without showing which call and why.
+- ❌ Severity inflation — not everything is critical.
+- ❌ Reproducing what `make lint` / `go vet` already reports.
+- ❌ Flagging code not present in the diff.

--- a/.claude/skills/find-bugs/SKILL.md
+++ b/.claude/skills/find-bugs/SKILL.md
@@ -19,9 +19,16 @@ prioritized report; user decides what to fix.
 BASE="${1:-main}"
 
 # If on a feature branch: diff vs base
-git rev-parse --verify "$BASE" 2>/dev/null && \
-  DIFF=$(git diff "$BASE"...HEAD) || \
-  DIFF=$(git diff HEAD~10...HEAD)
+if git rev-parse --verify "$BASE" >/dev/null 2>&1; then
+  DIFF=$(git diff "$BASE"...HEAD)
+else
+  if git rev-parse --verify --quiet HEAD~10 >/dev/null; then
+    BASE=HEAD~10
+  else
+    BASE=$(git rev-list --max-parents=0 HEAD | tail -1)
+  fi
+  DIFF=$(git diff "$BASE"...HEAD)
+fi
 
 # Fallback: on main with no base arg → recent commits
 if [[ -z "$DIFF" ]]; then
@@ -43,10 +50,7 @@ cat .claude/context-essentials.md 2>/dev/null
 
 # Detect stack
 cat go.mod 2>/dev/null | head -3
-cat package.json 2>/dev/null | python3 -c "
-import sys,json; d=json.load(sys.stdin)
-print({**d.get('dependencies',{}), **d.get('devDependencies',{})}.keys())
-" 2>/dev/null
+cat package.json 2>/dev/null | jq -r '(.dependencies // {}) + (.devDependencies // {}) | keys | join(", ")' 2>/dev/null
 
 # Changed files by type
 git diff "$BASE"...HEAD --name-only | sort

--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -324,7 +324,7 @@ PROMPT=$(printf '%s' "$PROMPT_TEMPLATE" | sed "s|{DIFF}|$(printf '%s' "$DIFF" | 
 RUN_DIR=$(mktemp -d -t fix-review-XXXX)
 WALL_START_MS=$(now_ms)
 
-REVIEW_SYSTEM_MSG="You are a senior code reviewer. Your entire response MUST be a raw JSON array — nothing else. Start with [ and end with ]. No prose, no markdown fences, no explanations before or after. If there are no issues output exactly: []"
+REVIEW_SYSTEM_MSG="You are a senior code reviewer. Your entire response MUST be a raw JSON array — nothing else. Start with [ and end with ]. No prose, no markdown fences, no explanations before or after. If there are no issues output exactly: [] Report at most 8 findings, most severe first; each body under 30 words. Do not include informational or 'no action needed' entries — only real issues."
 
 export PROVIDER REVIEWER_BLOCK API_URL API_KEY PROMPT RUN_DIR \
        MODEL_R1 MODEL_R2 MODEL_R3 REVIEW_SYSTEM_MSG
@@ -341,6 +341,22 @@ run_round() {
     '{model:$m,messages:[{role:"system",content:$sys},{role:"user",content:$user}],stream:false,think:$think}')
   response=$(rest_post "$API_URL" "$payload" "$API_KEY") \
     || response='{"_error":"rest_post_failed"}'
+
+  # Empty-content retry: reasoning models can return 200 + empty content
+  # on large diffs even with think:false. Retry once with a smaller
+  # num_predict cap before accepting a zero-finding round.
+  local content
+  content=$(printf '%s' "$response" | jq -r '.message.content // empty' 2>/dev/null)
+  if [ -n "$response" ] && [ -z "$(printf '%s' "$content" | tr -d '[:space:]')" ] \
+     && ! printf '%s' "$response" | jq -e '._error' >/dev/null 2>&1; then
+    echo "warn: round ${n} (${model}) returned empty content — retrying once with a tighter cap" >&2
+    payload=$(jq -n --arg m "$model" --arg sys "$REVIEW_SYSTEM_MSG" \
+      --arg user "$PROMPT" --argjson think "$think" \
+      '{model:$m,messages:[{role:"system",content:$sys},{role:"user",content:$user}],stream:false,think:$think,options:{num_predict:2000}}')
+    response=$(rest_post "$API_URL" "$payload" "$API_KEY") \
+      || response='{"_error":"rest_post_failed"}'
+  fi
+
   r_end=$(now_ms)
 
   printf '%s' "$response" > "$RUN_DIR/round_${n}.raw.json"

--- a/.claude/skills/session-recall/SKILL.md
+++ b/.claude/skills/session-recall/SKILL.md
@@ -130,6 +130,9 @@ Limitations:
   don't include the `Skill` tool — a spawned subagent can't invoke `/recall`
   or this skill itself mid-task. This section is for the orchestrator to run
   *before* spawning, not for the subagent to run on its own.
+  Same root cause as the general agent/skill boundary documented in
+  `~/wrk/common/skills/README.md`'s design principles — see that note
+  before assuming any skill will auto-trigger inside a subagent.
 - No tool-call noise filtering here (unlike `/recall <query>` and
   `session-recall.sh`) — the orchestrator curates what goes into the
   subagent prompt anyway; filter manually if a query pulls in noise.


### PR DESCRIPTION
## Summary

Follow-up to this morning's PR #26, per `~/wrk/common/tmp/session-indexer-sync-2026-07-12-pt2.md`:

1. **`find-bugs/SKILL.md`** — replaced wholesale with the library's rewrite (subagent dispatch per stack, context injection, dedup-by-`(file,line)` consolidation). No local edits to lose — confirmed via git log.
2. **`session-recall/SKILL.md`** — added a one-sentence cross-reference in Limitations, pointing to the library's design-principles doc.
3. **`fix-review/SKILL.md`** — targeted patch, not a file replace (this project's `fix-review` has genuinely diverged: CLI-agent provider tier, per-round `think` flag, inline `jq -n` payload). Added the empty-content retry to `run_round()` (Ollama reasoning models can return HTTP 200 + empty content on large diffs) and the `REVIEW_SYSTEM_MSG` output cap (max 8 findings, <30 words each).

Docs/`.claude/`-only diff — no Go source touched.

## Test plan

- [x] Confirmed `find-bugs`'s copy had no local edits since PR #25 (`git log`) before overwriting
- [x] Confirmed library `find-bugs/SKILL.md` has no `common`-specific paths
- [x] Verified `parse_round()` already reads `.message.content`, matching the retry patch's assumption
- [x] Confirmed `run_cli_round()` (this project's own CLI-agent extension) is untouched by the retry patch
- [x] Isolated bash test of the patched retry logic: retries on empty content, does not retry on valid content
- [ ] Next `/fix-review` run on a large diff — confirm no more silent zero-finding rounds from reasoning models

🤖 Generated with [Claude Code](https://claude.com/claude-code)