### PR TITLE
fix: resolve DB/log path via main checkout, not worktree toplevel

### DIFF
--- a/.claude/hooks/_lib/hook-common.sh
+++ b/.claude/hooks/_lib/hook-common.sh
@@ -8,10 +8,27 @@
 # hooks log separately (session-indexer -> ~/.cache/session-indexer/).
 # Override with HOOK_LOG_DIR.
 
+# Resolves the *main* checkout's root directory, even when invoked from a
+# linked git worktree (Claude Code uses worktrees by default for isolated
+# work). `git rev-parse --show-toplevel` returns the worktree's own path,
+# not the main checkout's — using it here would silently split the
+# per-project DB/log per worktree instead of sharing one across all of
+# them. `--git-common-dir` always resolves to the main checkout's `.git`
+# regardless of worktree; strip the trailing `/.git` to get its parent.
+# Falls back to $PWD outside a git repo.
+hook_project_root() {
+  local common_dir
+  common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || {
+    echo "$PWD"
+    return
+  }
+  dirname "$common_dir"
+}
+
 hook_setup_logging() {
   local script_name="$1"
   local project_name
-  project_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")")
+  project_name=$(basename "$(hook_project_root)")
   LOG_DIR="${HOOK_LOG_DIR:-${HOME}/.cache/${project_name}}"
   mkdir -p "$LOG_DIR" && chmod 700 "$LOG_DIR"
   LOG_FILE="$LOG_DIR/hooks.log"

--- a/.claude/hooks/session-index.sh
+++ b/.claude/hooks/session-index.sh
@@ -23,7 +23,7 @@ if ! command -v session-indexer >/dev/null 2>&1; then
     exit 0
 fi
 
-PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
+PROJECT_ROOT=$(hook_project_root)
 DB="$PROJECT_ROOT/.claude/sessions.db"
 
 echo "[$(date -Iseconds)] session-index: mining $(basename "$TRANSCRIPT") → $DB" >> "$LOG_FILE"

--- a/.claude/hooks/session-recall.sh
+++ b/.claude/hooks/session-recall.sh
@@ -17,7 +17,7 @@ if ! command -v session-indexer >/dev/null 2>&1; then
     exit 0
 fi
 
-PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
+PROJECT_ROOT=$(hook_project_root)
 DB="$PROJECT_ROOT/.claude/sessions.db"
 
 if [[ ! -f "$DB" ]]; then

--- a/.claude/skills/session-recall/SKILL.md
+++ b/.claude/skills/session-recall/SKILL.md
@@ -19,7 +19,7 @@ BM25 keyword fallback. Requires `session-indexer` in PATH and a local
 ## /recall \<query\>
 
 ```bash
-PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
+GCD=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && PROJECT_ROOT=$(dirname "$GCD") || PROJECT_ROOT="$PWD"
 DB="$PROJECT_ROOT/.claude/sessions.db"
 
 if [[ ! -f "$DB" ]]; then
@@ -57,7 +57,7 @@ printf '%s' "$RESULTS" | jq -r '
 ## /recall stats
 
 ```bash
-PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
+GCD=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && PROJECT_ROOT=$(dirname "$GCD") || PROJECT_ROOT="$PWD"
 DB="$PROJECT_ROOT/.claude/sessions.db"
 
 if [[ ! -f "$DB" ]]; then
@@ -95,7 +95,8 @@ automatic BM25 FTS5 fallback when embeddings are absent.
 **Troubleshooting**:
 ```bash
 # Check hook logs
-tail -30 ~/.cache/$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")")/hooks.log
+GCD=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && PROJ=$(basename "$(dirname "$GCD")") || PROJ=$(basename "$PWD")
+tail -30 ~/.cache/"$PROJ"/hooks.log
 
 # Manual index check
 session-indexer stats --db .claude/sessions.db
@@ -115,7 +116,7 @@ history yourself *before* spawning it, then fold the relevant results into
 the subagent's prompt (subagent prompts must be self-contained).
 
 ```bash
-PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
+GCD=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && PROJECT_ROOT=$(dirname "$GCD") || PROJECT_ROOT="$PWD"
 DB="$PROJECT_ROOT/.claude/sessions.db"
 
 [[ -f "$DB" ]] && command -v session-indexer >/dev/null 2>&1 || exit 0

--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ embeddings exist, not for a partial store. Fix: run `session-indexer embed`.
 
 **Read hook logs:**
 ```bash
-tail -40 ~/.cache/$(basename "$(git rev-parse --show-toplevel)")/hooks.log
+GCD=$(git rev-parse --path-format=absolute --git-common-dir) && PROJ=$(basename "$(dirname "$GCD")") || PROJ=$(basename "$PWD")
+tail -40 ~/.cache/"$PROJ"/hooks.log
 ```
 
 **DB size:** scale assumption is <10k chunks (~40MB vectors in memory). No hard

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -322,7 +322,7 @@ INPUT=$(cat)
 TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')
 [[ -z "$TRANSCRIPT" || ! -f "$TRANSCRIPT" ]] && exit 0
 command -v session-indexer >/dev/null 2>&1 || exit 0
-PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
+PROJECT_ROOT=$(hook_project_root)   # main checkout root, even from a worktree
 session-indexer mine "$TRANSCRIPT" --db "$PROJECT_ROOT/.claude/sessions.db"
 ```
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -42,6 +42,9 @@ The tool must find relevant conversation chunks given a natural-language query.
 Each project maintains its own independent index.
 
 - Index lives at `<project-root>/.claude/sessions.db` (gitignored)
+- `<project-root>` resolves to the main checkout, even when invoked from a
+  linked git worktree — so every worktree of the same repo shares one DB
+  instead of each starting a fresh, empty one (see FR-1 note below)
 - Corruption or deletion of one project's DB does not affect any other
 - No shared daemon, no shared port, no shared state
 
@@ -110,7 +113,7 @@ both languages with equivalent quality.
 - SQLite via `modernc.org/sqlite` (pure Go, no CGO)
 - Ollama local: `bge-m3:latest` for embeddings (1024 dims)
 - Claude Code JSONL format: lines of JSON, `type` field discriminates records; `sessionId` field present in each record (used as session_id; fall back to filename stem if absent)
-- Project root detected via `git rev-parse --show-toplevel` or passed explicitly
+- Project root detected via `git rev-parse --path-format=absolute --git-common-dir` (parent of the main checkout's `.git`, stable across worktrees) or passed explicitly
 - JSONL files at `~/.claude/projects/<hash>/<session-id>.jsonl` — may be
   deleted by Claude Code cleanup; must mine at Stop hook time
 


### PR DESCRIPTION
Fixes #23.

## Summary

- Claude Code uses linked git worktrees by default for isolated work (e.g. code-generator/`/ship`). `git rev-parse --show-toplevel` returns the worktree's own directory, not the main checkout's.
- Since `.claude/sessions.db` is gitignored (correctly — this is a single-user tool, no need to share it), a linked worktree never saw the main checkout's existing DB and silently started a fresh, empty one, losing session history continuity.
- Same bug independently affected `hook_setup_logging()`'s per-project log directory, fragmenting `hooks.log` per worktree.
- Reframed from the original issue text: the "add DB to git" concern (merge conflicts, teammate syncing) doesn't apply — this tool is single-user, not team-shared. Posted this framing to the issue for confirmation before implementing.

## Fix

Added `hook_project_root()` to `_lib/hook-common.sh`, anchored on `git rev-parse --path-format=absolute --git-common-dir` (always resolves to the main checkout's `.git` regardless of worktree) instead of `--show-toplevel`. Updated `session-index.sh`, `session-recall.sh`, and `hook_setup_logging()` to use it. Applied the equivalent inline pattern to `session-recall/SKILL.md`'s `/recall` examples and `README.md`'s troubleshooting snippet (skill-invocation docs, not scripts that source `hook-common.sh`).

## Test plan

- [x] `bash -n` syntax check on all modified shell scripts
- [x] Unit-verified `hook_project_root()` resolves correctly from both the main repo and a linked worktree, and falls back to `$PWD` outside a git repo
- [x] End-to-end: mined a transcript from the main repo, then from a linked worktree — confirmed no local `.claude/sessions.db` was created in the worktree, the second mine correctly deduped against the shared DB (`INSERT OR IGNORE`), and `session-recall.sh` returned real results when run from the worktree
- [x] `go build`/`go vet` pass (unaffected — no Go source touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)