### PR TITLE
fix: patch-pin go.mod to 1.26.5, fixing GO-2026-5856 in CI vulncheck

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Primary: embed query → exhaustive cosine over all `embeddings` rows loaded int
 ## Key Constraints
 
 - **Pure Go, no CGO.** `go build` must produce a portable static binary.
-- **Go 1.26+.** Use `go 1.26` in `go.mod`.
+- **Go 1.26.5+.** Use `go 1.26.5` in `go.mod` (patch-pinned — `1.26.4` had GO-2026-5856, a `crypto/tls` ECH privacy leak fixed in `1.26.5`; see issue #31).
 - **60-second budget.** `mine` runs inside a Claude Code Stop hook. Must complete well within 60s (enforced internally via a 50s `context.Context` deadline — see Embeddings).
 - **Mixed Ukrainian + English content.** `bge-m3` handles both; `unicode61 remove_diacritics 0` tokenizer for FTS5.
 - **Per-project isolation.** No cross-project search, no shared state.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -285,7 +285,7 @@ session-indexer/
 │   │   └── session-recall/SKILL.md  — /recall <query> skill + orchestrator subagent-prep section
 │   └── settings.local.json
 ├── .gitignore
-├── go.mod                   — go 1.26
+├── go.mod                   — go 1.26.5
 └── Makefile
 ```
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -106,7 +106,7 @@ both languages with equivalent quality.
 
 ## Constraints
 
-- Go 1.26.5+ (project language; patch-pinned in `go.mod` — `1.26.4` had GO-2026-5856, a `crypto/tls` ECH privacy leak fixed in `1.26.5`)
+- Go 1.26.5+ (project language; patch-pinned in `go.mod` — `1.26.4` had GO-2026-5856, a `crypto/tls` ECH privacy leak fixed in `1.26.5`; see issue #31)
 - SQLite via `modernc.org/sqlite` (pure Go, no CGO)
 - Ollama local: `bge-m3:latest` for embeddings (1024 dims)
 - Claude Code JSONL format: lines of JSON, `type` field discriminates records; `sessionId` field present in each record (used as session_id; fall back to filename stem if absent)

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -106,7 +106,7 @@ both languages with equivalent quality.
 
 ## Constraints
 
-- Go 1.26+ (project language; confirmed go1.26.4)
+- Go 1.26.5+ (project language; patch-pinned in `go.mod` — `1.26.4` had GO-2026-5856, a `crypto/tls` ECH privacy leak fixed in `1.26.5`)
 - SQLite via `modernc.org/sqlite` (pure Go, no CGO)
 - Ollama local: `bge-m3:latest` for embeddings (1024 dims)
 - Claude Code JSONL format: lines of JSON, `type` field discriminates records; `sessionId` field present in each record (used as session_id; fall back to filename stem if absent)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/valpere/session-indexer
 
-go 1.26
+go 1.26.5
 
 require (
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
Fixes #31.

## Summary

`go.mod` pinned `go 1.26` (no patch version), so `actions/setup-go@v6` resolved it to whatever `1.26.x` build was current when the CI runner picked up the toolchain — `go1.26.4`, which carries GO-2026-5856 (`crypto/tls` ECH privacy leak, fixed in `1.26.5`). This made CI's `vulncheck` job fail on every PR since 2026-07-12 regardless of the actual diff content (confirmed pre-existing/out-of-scope on PRs #25–#30).

- Pinned `go.mod` to `go 1.26.5` instead of relying on `setup-go`'s cache to eventually pick up the fix for the loose `1.26` resolution.
- Updated the three docs that stated the Go version (`CLAUDE.md`, `docs/requirements.md`, `docs/architecture.md`) to match.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (all 4 packages)
- [x] `go mod tidy` — no drift
- [x] `govulncheck ./...` locally reports clean on go1.26.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)