### PR TITLE
chore: gitignore self-learn accumulated state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,10 @@ vendor/
 # Skills telemetry
 .claude/skills/fix-review/telemetry.jsonl
 
+# Self-learn accumulated state — per-machine log, not shared skill config
+.claude/skills/self-learn/_patterns/
+.claude/skills/self-learn/_knowledge-base/
+
 # SDD scratch — implementation plans written by writing-plans skill
 docs/superpowers/
 


### PR DESCRIPTION
## Summary

- `.claude/skills/self-learn/_patterns/` and `_knowledge-base/` are per-machine accumulated logs (mistakes.jsonl, wins.jsonl, decisions.md, etc.) — same nature as `sessions.db`/`session-log.md`, not shared skill config.
- Initialized this state for the first time while shipping issue #31; without this entry it would show as untracked and grow the review surface of every future PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)