### PR TITLE
feat: add facts layer — distill and query subject-predicate-object claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,22 +23,24 @@ Raw `go` invocations still work if you don't want to use make:
 
 ## Architecture
 
-Single Go binary, no daemon, no shared state between projects. Four subcommands via Cobra:
+Single Go binary, no daemon, no shared state between projects. Six subcommands via Cobra (`facts` has four child verbs):
 
 ```
-session-indexer mine   <jsonl-path> --db <path>        # parse JSONL → SQLite
-session-indexer search <query>      --db <path> [--limit N] [--json]
-session-indexer embed               --db <path>        # backfill missing embeddings
-session-indexer stats               --db <path>        # sessions, chunks, pending, DB size
+session-indexer mine    <jsonl-path> --db <path>        # parse JSONL → SQLite
+session-indexer search  <query>      --db <path> [--limit N] [--json]
+session-indexer embed                --db <path>        # backfill missing embeddings
+session-indexer stats                --db <path>        # sessions, chunks, facts, pending, DB size
+session-indexer distill              --db <path> [--threshold 0.7]   # LLM-extract facts, manual, no deadline
+session-indexer facts search/get/related/supersede --db <path>       # query the facts layer
 ```
 
 ### File Layout
 
 ```
 cmd/session-indexer/main.go       — Cobra root + subcommands
-internal/types.go                 — shared row types: Chunk, SearchResult
+internal/types.go                 — shared row types: Chunk, SearchResult, Fact
 internal/db/
-  db.go                           — open, WAL, busy_timeout, schema version check
+  db.go                           — open, WAL, busy_timeout, schema version check; fact CRUD
   schema.sql                      — embedded via go:embed
 internal/mine/
   mine.go                         — orchestrate: parse → chunk → store → embed (two-phase: store first, embed respects ctx deadline; deferred chunks backfilled via `embed`). Defines `mine.Result` (ChunksInserted / Embedded / Skipped / Deferred).
@@ -47,7 +49,11 @@ internal/mine/
 internal/embed/
   embed.go                        — Ollama client, probe+model-check, float32 BLOB
 internal/search/
-  search.go                       — exhaustive cosine; FTS5 BM25 fallback
+  search.go                       — exhaustive cosine; FTS5 BM25 fallback; Stats
+internal/distill/
+  distill.go                      — Ollama generate client + orchestration: confidence gate (deterministic Go check, not LLM-enforced), automatic supersession with a validated-against-context safeguard
+internal/facts/
+  facts.go                        — read verbs: Search (FTS5 BM25), Get (supersedes edges), Related (depth-1)
 ```
 
 ### Storage
@@ -71,6 +77,14 @@ Ollama REST: `POST localhost:11434/api/embed`, model `bge-m3:latest` (1024 dims)
 ### Search
 
 Primary: embed query → exhaustive cosine over all `embeddings` rows loaded into memory. Scale assumption: <10k chunks. Fallback to FTS5 BM25 when Ollama is unavailable **OR** the store has zero embeddings (e.g. mined while Ollama was down); FTS uses per-term OR recall, not phrase match. Output notes when the fallback is used.
+
+### Facts Layer
+
+Distilled subject-predicate-object claims, separate from raw-text `search`. `distill` (manual, never hooked into `mine`/Stop-hook budget — `context.Background()`, 120s HTTP timeout) calls Ollama `/api/generate` (`OLLAMA_DISTILL_MODEL`, default `qwen2.5:latest`) per chunk not yet in `distilled_chunks`, feeding it a bounded `CurrentFacts` context (cap 200) for supersession judgment.
+
+Confidence gate is a **deterministic Go check** (default 0.7), not an LLM-enforced instruction — the model's self-reported confidence is advisory input only. Supersession is judged automatically by the model, but the model may only cite fact ids from the context it was actually given (validated in Go); `SupersedeFact` no-ops (not an error) on an already-tombstoned fact. `facts supersede <new> <old>` is a manual audit/override backstop using the same function. See `docs/architecture.md`'s "Facts Layer" section for the full design rationale (deliberate deviations from litopys).
+
+Tombstone resolution is filter-based (`WHERE until IS NULL`), not chain-walking. `facts get`/`facts related` are depth-1 only — no BFS.
 
 ## Key Constraints
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ can break another.
 
 ## Prerequisites
 
-- **Go 1.26+** — to build the binary
+- **Go 1.26.5+** — to build the binary
 - **Ollama** — for vector embeddings (optional but recommended)
   - Install: [ollama.com/download](https://ollama.com/download) — native packages for macOS, Linux, Windows
   - `ollama pull bge-m3:latest` — 1024-dim multilingual model (EN + UA)
@@ -85,10 +85,15 @@ go install ./cmd/session-indexer   # to PATH (activates the Stop hook guard)
 ## Usage
 
 ```bash
-session-indexer mine   <jsonl-path> --db .claude/sessions.db
-session-indexer search <query>      --db .claude/sessions.db [--limit N] [--json]
-session-indexer embed               --db .claude/sessions.db
-session-indexer stats               --db .claude/sessions.db
+session-indexer mine    <jsonl-path> --db .claude/sessions.db
+session-indexer search  <query>      --db .claude/sessions.db [--limit N] [--json]
+session-indexer embed                --db .claude/sessions.db
+session-indexer stats                --db .claude/sessions.db
+session-indexer distill              --db .claude/sessions.db [--threshold 0.7]
+session-indexer facts search   <query>            --db .claude/sessions.db [--limit N] [--json] [--include-expired]
+session-indexer facts get      <id>               --db .claude/sessions.db [--json]
+session-indexer facts related  <id>               --db .claude/sessions.db [--json]
+session-indexer facts supersede <new-id> <old-id> --db .claude/sessions.db
 ```
 
 ### `mine` output
@@ -118,6 +123,33 @@ mined: 23 chunks inserted, 21 embedded, 0 skipped, 2 deferred
 `Score` is cosine similarity (0–1) in embedding mode, or negated BM25 rank in
 FTS5 fallback mode (higher is always better in both cases).
 
+### Facts layer — `distill` and `facts`
+
+A separate, manually-invoked layer that distills durable
+subject-predicate-object facts from mined chunks via an LLM call, alongside
+the raw-text `search` above. Never runs automatically — not wired into the
+Stop hook, no deadline. See ["Facts Layer"](docs/architecture.md#facts-layer)
+in the architecture doc for the full design (confidence gate, supersession
+safeguards).
+
+```bash
+# Extract facts from chunks not yet distilled (idempotent — safe to re-run)
+session-indexer distill --db .claude/sessions.db --threshold 0.7
+# → Distilled 12 chunks: 5 facts stored, 3 below threshold, 1 superseded
+
+# Query
+session-indexer facts search "implementation status" --db .claude/sessions.db
+# → [7] session-indexer | has | 33 merged PRs (confidence 0.92)
+
+session-indexer facts get 7 --db .claude/sessions.db
+# → shows the fact plus any incoming/outgoing supersedes edges
+
+session-indexer facts related 7 --db .claude/sessions.db
+
+# Manual override (audit/backstop — distill already judges supersession automatically)
+session-indexer facts supersede 9 7 --db .claude/sessions.db
+```
+
 ## Embeddings
 
 Requires Ollama on `localhost:11434` with `bge-m3:latest`. Override with
@@ -127,6 +159,7 @@ environment variables:
 |---|---|---|
 | `OLLAMA_HOST` | `http://localhost:11434` | Ollama base URL (scheme optional: `localhost:11434` works) |
 | `OLLAMA_MODEL` | `bge-m3:latest` | Embedding model name |
+| `OLLAMA_DISTILL_MODEL` | `qwen2.5:latest` | Chat/generate model used by `distill` — distinct from `OLLAMA_MODEL`, must be pulled separately (`ollama pull qwen2.5:latest` or your chosen model) |
 
 `mine` runs with a 50s `context.Context` deadline (headroom under the 60s
 Stop-hook budget): storing is fast and unconditional; embedding respects the
@@ -207,6 +240,30 @@ worktrees rather than sharing it. This is a known limitation, not
 intentional design (per-project isolation is intentional — see
 [`docs/requirements.md`](docs/requirements.md) FR-3 — worktree splitting
 within one project isn't). If this affects your workflow, open an issue.
+
+## Querying facts (discipline)
+
+The facts layer is a supersedable claim store, not a flat lookup table — a
+matching search hit is not automatically the current truth. For any
+non-trivial answer drawn from `facts`, follow all four steps before citing
+a fact:
+
+1. **`facts search <query>`** — find candidate facts.
+2. **`facts get <id>`** — read the fact plus its supersedes edges.
+3. **`facts related <id>`** — check for an *incoming* supersedes edge (a
+   newer fact that replaced this one). If present, jump to the newer fact
+   and repeat from step 2.
+4. **Check `until`** — a non-null `until` means the fact is tombstoned;
+   don't cite it as current (it's still visible via `--include-expired`
+   for historical context, but never as present-tense truth).
+
+**Anti-pattern:** answering after step 1 alone. `facts search` ranks by
+keyword match, not recency or validity — a stale, superseded fact can
+easily outrank its replacement on pure BM25 score if it happens to phrase
+the query terms more directly. Skipping steps 2–4 is exactly how a
+distilled-but-superseded fact (e.g. an old "implementation not started"
+claim) gets cited as current truth — the same class of drift this feature
+exists to catch.
 
 ## Troubleshooting
 

--- a/cmd/session-indexer/main.go
+++ b/cmd/session-indexer/main.go
@@ -5,13 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/valpere/session-indexer/internal"
 	"github.com/valpere/session-indexer/internal/db"
+	"github.com/valpere/session-indexer/internal/distill"
 	"github.com/valpere/session-indexer/internal/embed"
+	"github.com/valpere/session-indexer/internal/facts"
 	"github.com/valpere/session-indexer/internal/mine"
 	"github.com/valpere/session-indexer/internal/search"
 )
@@ -128,13 +131,145 @@ func main() {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Sessions indexed: %d\nChunks total:     %d\nWith embeddings:  %d (%d pending)\nOldest entry:     %s\nNewest entry:     %s\nDB size:          %s\n",
-				st.Sessions, st.Chunks, st.Embedded, st.Pending, st.Oldest, st.Newest, st.DBSize)
+			fmt.Printf("Sessions indexed: %d\nChunks total:     %d\nWith embeddings:  %d (%d pending)\nFacts current:    %d\nPending distill:  %d\nOldest entry:     %s\nNewest entry:     %s\nDB size:          %s\n",
+				st.Sessions, st.Chunks, st.Embedded, st.Pending, st.Facts, st.PendingDistill, st.Oldest, st.Newest, st.DBSize)
 			return nil
 		},
 	}
 
-	root.AddCommand(mineCmd, searchCmd, embedCmd, statsCmd)
+	var threshold float64
+	distillCmd := &cobra.Command{
+		Use:   "distill",
+		Short: "Extract structured facts from mined chunks (LLM, Ollama)",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if dbPath == "" {
+				return fmt.Errorf("--db is required")
+			}
+			return runDistill(dbPath, threshold)
+		},
+	}
+	distillCmd.Flags().Float64Var(&threshold, "threshold", 0.7, "minimum confidence to store a fact")
+
+	var factsLimit int
+	var factsJSON bool
+	var includeExpired bool
+	factsSearchCmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Keyword search over distilled facts",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if dbPath == "" {
+				return fmt.Errorf("--db is required")
+			}
+			d, err := db.Open(dbPath)
+			if err != nil {
+				return err
+			}
+			defer d.Close()
+			res, err := facts.Search(d, args[0], factsLimit, includeExpired)
+			if err != nil {
+				return err
+			}
+			return printFacts(res, factsJSON)
+		},
+	}
+	factsSearchCmd.Flags().IntVar(&factsLimit, "limit", 5, "max results")
+	factsSearchCmd.Flags().BoolVar(&factsJSON, "json", false, "machine-readable output")
+	factsSearchCmd.Flags().BoolVar(&includeExpired, "include-expired", false, "include tombstoned facts")
+
+	var factsGetJSON bool
+	factsGetCmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Show a fact and its supersedes edges",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if dbPath == "" {
+				return fmt.Errorf("--db is required")
+			}
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid fact id %q: %w", args[0], err)
+			}
+			d, err := db.Open(dbPath)
+			if err != nil {
+				return err
+			}
+			defer d.Close()
+			fact, incoming, outgoing, err := facts.Get(d, id)
+			if err != nil {
+				return err
+			}
+			return printFactDetail(fact, incoming, outgoing, factsGetJSON)
+		},
+	}
+	factsGetCmd.Flags().BoolVar(&factsGetJSON, "json", false, "machine-readable output")
+
+	var factsRelatedJSON bool
+	factsRelatedCmd := &cobra.Command{
+		Use:   "related <id>",
+		Short: "List facts depth-1 related via supersedes",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if dbPath == "" {
+				return fmt.Errorf("--db is required")
+			}
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid fact id %q: %w", args[0], err)
+			}
+			d, err := db.Open(dbPath)
+			if err != nil {
+				return err
+			}
+			defer d.Close()
+			res, err := facts.Related(d, id)
+			if err != nil {
+				return err
+			}
+			return printFacts(res, factsRelatedJSON)
+		},
+	}
+	factsRelatedCmd.Flags().BoolVar(&factsRelatedJSON, "json", false, "machine-readable output")
+
+	factsSupersedeCmd := &cobra.Command{
+		Use:   "supersede <new-id> <old-id>",
+		Short: "Manually tombstone old-id in favor of new-id (audit/override backstop)",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if dbPath == "" {
+				return fmt.Errorf("--db is required")
+			}
+			newID, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid new-id %q: %w", args[0], err)
+			}
+			oldID, err := strconv.ParseInt(args[1], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid old-id %q: %w", args[1], err)
+			}
+			d, err := db.Open(dbPath)
+			if err != nil {
+				return err
+			}
+			defer d.Close()
+			changed, err := db.SupersedeFact(d, newID, oldID, time.Now().UTC().Format(time.RFC3339))
+			if err != nil {
+				return err
+			}
+			if !changed {
+				fmt.Printf("fact %d was already tombstoned; no change made\n", oldID)
+				return nil
+			}
+			fmt.Printf("fact %d superseded by %d\n", oldID, newID)
+			return nil
+		},
+	}
+
+	factsCmd := &cobra.Command{Use: "facts", Short: "Query the distilled facts layer"}
+	factsCmd.AddCommand(factsSearchCmd, factsGetCmd, factsRelatedCmd, factsSupersedeCmd)
+
+	root.AddCommand(mineCmd, searchCmd, embedCmd, statsCmd, distillCmd, factsCmd)
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(1)
@@ -175,6 +310,30 @@ func runEmbed(dbPath string) error {
 	return nil
 }
 
+func runDistill(dbPath string, threshold float64) error {
+	d, err := db.Open(dbPath)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	cli := distill.NewClient()
+	if !cli.Available() {
+		return fmt.Errorf("ollama unavailable — start it and pull the distill model (OLLAMA_DISTILL_MODEL)")
+	}
+	// distill is a manual, non-time-boxed command, explicitly exempt from
+	// mine's 50s/Stop-hook budget (NFR-4).
+	res, err := distill.Run(context.Background(), d, cli, distill.Config{Threshold: threshold, ContextCap: 200})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Distilled %d chunks: %d facts stored, %d below threshold, %d superseded\n",
+		res.ChunksDistilled, res.FactsInserted, res.BelowThreshold, res.Superseded)
+	if res.Failed > 0 {
+		fmt.Fprintf(os.Stderr, "warn: %d chunks failed to distill\n", res.Failed)
+	}
+	return nil
+}
+
 func printResults(res []internal.SearchResult, usedEmbeddings, asJSON bool) error {
 	if asJSON {
 		enc := json.NewEncoder(os.Stdout)
@@ -205,4 +364,58 @@ func snippet(s string) string {
 		cut = cut[:i]
 	}
 	return cut + "…"
+}
+
+func printFacts(res []internal.Fact, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(res)
+	}
+	for _, f := range res {
+		fmt.Printf("[%d] %s | %s | %s (confidence %.2f)%s\n",
+			f.ID, f.Subject, f.Predicate, f.Object, f.Confidence, factStatusSuffix(f))
+	}
+	if len(res) == 0 {
+		fmt.Println("(no results)")
+	}
+	return nil
+}
+
+func printFactDetail(fact internal.Fact, incoming, outgoing []internal.Fact, asJSON bool) error {
+	if asJSON {
+		out := struct {
+			Fact     internal.Fact   `json:"fact"`
+			Incoming []internal.Fact `json:"incoming"`
+			Outgoing []internal.Fact `json:"outgoing"`
+		}{fact, incoming, outgoing}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	}
+	fmt.Printf("[%d] %s | %s | %s (confidence %.2f)%s\n",
+		fact.ID, fact.Subject, fact.Predicate, fact.Object, fact.Confidence, factStatusSuffix(fact))
+	if len(incoming) > 0 {
+		fmt.Println("Superseded by this fact:")
+		for _, f := range incoming {
+			fmt.Printf("  [%d] %s | %s | %s\n", f.ID, f.Subject, f.Predicate, f.Object)
+		}
+	}
+	if len(outgoing) > 0 {
+		fmt.Println("Superseded by:")
+		for _, f := range outgoing {
+			fmt.Printf("  [%d] %s | %s | %s\n", f.ID, f.Subject, f.Predicate, f.Object)
+		}
+	}
+	return nil
+}
+
+func factStatusSuffix(f internal.Fact) string {
+	if f.Until == nil {
+		return ""
+	}
+	if f.SupersededBy != nil {
+		return fmt.Sprintf(" [tombstoned %s, superseded by %d]", *f.Until, *f.SupersededBy)
+	}
+	return fmt.Sprintf(" [tombstoned %s]", *f.Until)
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,15 +4,21 @@
 
 ## Overview
 
-A single Go binary with four subcommands. No daemon, no server, no shared
-state between projects.
+A single Go binary with six subcommands (`facts` has four child verbs). No
+daemon, no server, no shared state between projects.
 
 ```
 session-indexer
 ├── mine    — parse JSONL → index into SQLite (chunks + embeddings)
 ├── embed   — backfill embeddings for chunks that lack them
 ├── search  — embedding-first cosine; FTS5 fallback when Ollama unavailable
-└── stats   — report index state
+├── stats   — report index state
+├── distill — extract structured facts from mined chunks (LLM, manual)
+└── facts   — query the distilled facts layer
+    ├── search     — FTS5 keyword search
+    ├── get        — one fact + supersedes edges
+    ├── related    — depth-1 supersedes neighbors
+    └── supersede  — manual tombstone (audit/override backstop)
 ```
 
 ---
@@ -64,7 +70,7 @@ CREATE TABLE meta (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
--- populated on DB creation: INSERT INTO meta VALUES ('schema_version', '1');
+-- populated on DB creation: INSERT INTO meta VALUES ('schema_version', '2');
 
 CREATE TABLE chunks (
     id            INTEGER PRIMARY KEY,
@@ -102,6 +108,46 @@ CREATE TABLE embeddings (
 -- Dedup key: positional within session, stable across re-mines
 CREATE UNIQUE INDEX idx_chunks_dedup
     ON chunks(session_id, message_index, chunk_index);
+
+-- Distilled facts: flat subject-predicate-object triples. No per-type node
+-- tables, no separate edges table — supersedes is the only relation and is
+-- functional/at-most-one, so a self-referential superseded_by column
+-- captures it fully.
+CREATE TABLE facts (
+    id              INTEGER PRIMARY KEY,
+    subject         TEXT    NOT NULL,
+    predicate       TEXT    NOT NULL,
+    object          TEXT    NOT NULL,
+    confidence      REAL    NOT NULL,
+    source_chunk_id INTEGER REFERENCES chunks(id) ON DELETE SET NULL,
+    session_date    TEXT    NOT NULL,   -- denormalized from source chunk
+    created_at      TEXT    NOT NULL,   -- distilled-at
+    until           TEXT,               -- tombstone; NULL = currently valid
+    superseded_by   INTEGER REFERENCES facts(id) ON DELETE SET NULL
+);
+
+-- FTS5 mirrors chunks_fts exactly (same tokenizer, same trigger shape)
+CREATE VIRTUAL TABLE facts_fts USING fts5(
+    subject, predicate, object,
+    content='facts', content_rowid='id',
+    tokenize="unicode61 remove_diacritics 0"
+);
+CREATE TRIGGER facts_ai AFTER INSERT ON facts BEGIN
+    INSERT INTO facts_fts(rowid, subject, predicate, object)
+    VALUES (new.id, new.subject, new.predicate, new.object);
+END;
+CREATE TRIGGER facts_ad AFTER DELETE ON facts BEGIN
+    INSERT INTO facts_fts(facts_fts, rowid, subject, predicate, object)
+    VALUES ('delete', old.id, old.subject, old.predicate, old.object);
+END;
+
+-- Distill progress marker, decoupled from produced facts — a chunk
+-- legitimately yields zero facts, so "has a facts row" can't double as
+-- the pending marker (that would re-distill zero-fact chunks forever).
+CREATE TABLE distilled_chunks (
+    chunk_id     INTEGER PRIMARY KEY REFERENCES chunks(id) ON DELETE CASCADE,
+    distilled_at TEXT NOT NULL
+);
 ```
 
 On DB open:
@@ -247,6 +293,122 @@ The config validation approach using JSON Schema has a key advantage...
 
 ---
 
+## Facts Layer
+
+A distilled, structured layer of subject-predicate-object claims sitting
+alongside the raw-text `search`. Ported (scoped down) from litopys — see
+"Explicitly out of scope" in `docs/requirements.md` for what was
+deliberately left out. Closes a gap raw-text search cannot: a stale fact
+about a project (e.g. "implementation not started") surfaces only during
+periodic review unless something distills and tombstones it at index time.
+
+### Distill flow
+
+```
+session-indexer distill --db <path> [--threshold 0.7]
+    │
+    └─ for each chunk in ChunksWithoutFacts (distilled_chunks marker):
+         │
+         ├─ CurrentFacts(limit=ContextCap) — bounded context of
+         │  non-tombstoned facts, fed to the model for supersession judgment
+         │
+         ├─ POST /api/generate  { model: OLLAMA_DISTILL_MODEL, chunk, existing facts }
+         │  → candidates: [{subject, predicate, object, confidence, supersedes_ids}]
+         │
+         ├─ per candidate:
+         │    confidence < threshold?  → discard (BelowThreshold++)
+         │    else → InsertFact; for each supersedes_ids entry validated
+         │           against the context actually given → SupersedeFact
+         │
+         └─ MarkChunkDistilled — regardless of fact count (zero-fact chunks
+            must not be re-distilled forever)
+```
+
+`distill` is a separate, manually-invoked subcommand — it never hooks into
+`mine`'s two-phase run or its 50s Stop-hook deadline. `context.Background()`
+governs each chunk's `Distill` call internally.
+
+### Confidence gate — a deliberate deviation from litopys
+
+The gate (default 0.7) is a **deterministic Go check**
+(`internal/distill.Run`), not an LLM-enforced instruction. litopys's
+equivalent 0.7 threshold is instructional/human-reviewed, backed by a
+quarantine-and-promote workflow. session-indexer has no such review loop
+(the existing `dreaming`/`apply-dreaming` cycle already covers that role),
+so the model's self-reported confidence is treated as advisory input to a
+hard code-level check, not the enforcement mechanism itself.
+
+### Supersession — automatic, with a manual backstop
+
+The distill call judges supersession automatically, given the bounded
+`CurrentFacts` context. This is a deliberate deviation from litopys, which
+has no automated supersession at all — only explicit human/agent
+`litopys_link` calls. A purely-manual approach (litopys's model) just
+relocates the same review burden this feature exists to remove; a
+deterministic same-subject-different-object heuristic produces false
+positives on paraphrase and misses genuine contradictions phrased
+differently — exactly the language problem an LLM call is already solving
+mid-chunk.
+
+Safeguards:
+- The model may only cite fact ids from the context it was actually given
+  (`Run` validates every `supersedes_ids` entry against the provided set —
+  `TestRunRejectsSupersedeIDOutsideContext` covers this)
+- The superseding fact must itself pass the confidence gate before it's
+  inserted
+- `SupersedeFact` only tombstones a fact whose `until IS NULL` — a no-op
+  (not an error) if already tombstoned, so re-application is safe
+- Every auto-supersession is reversible/auditable via the preserved
+  `superseded_by` edge; `facts supersede <new> <old>` exists as a manual
+  audit/override backstop using the same `SupersedeFact` function
+
+If the current-facts set exceeds `ContextCap` (200), the distill call omits
+context entirely for that chunk and auto-supersession is skipped for it —
+an oversized context blows the prompt budget and the model has nothing
+reliable to judge supersession against.
+
+### Tombstone / supersedes resolution
+
+Filter-based, not chain-walking — the one litopys algorithm ported
+near-verbatim. `facts search` and `stats`'s current-facts count both filter
+on `WHERE until IS NULL`; there is no recursive walk of `superseded_by`
+chains. `facts get <id>` and `facts related <id>` are depth-1 only:
+`incoming` (facts whose `superseded_by = id`) and `outgoing` (what `id`'s
+own `superseded_by` points to, if any). No BFS, no multi-hop traversal —
+YAGNI until a real need surfaces (see requirements.md's Out of Scope).
+
+### Distill model
+
+Ollama REST call:
+```
+POST http://localhost:11434/api/generate   (default; override with OLLAMA_HOST)
+{
+  "model": "qwen2.5:latest",   (default; override with OLLAMA_DISTILL_MODEL —
+                                 a chat/generate model, distinct from
+                                 bge-m3:latest; must be pulled separately)
+  "prompt": "<template with CURRENT KNOWN FACTS + CHUNK>",
+  "stream": false,
+  "format": "json"
+}
+→ { "response": "{\"facts\":[...]}" }
+```
+
+120s HTTP client timeout (vs embed's 30s) — generate is a larger completion
+than a single embedding vector. Single attempt, no retry — matches embed's
+documented no-retry convention; a failed chunk is left un-distilled
+(`Failed++`, not marked in `distilled_chunks`) and retried on the next run.
+
+Availability probe is the identical `GET /api/tags` (2s timeout) pattern
+used by `embed` — if the configured `OLLAMA_DISTILL_MODEL` isn't in the tag
+list, `distill` fails gracefully with `ollama unavailable — start it and
+pull the distill model (OLLAMA_DISTILL_MODEL)`, matching NFR-1.
+
+### Changelog
+
+**2026-07-18** — Added the facts layer (`distill`, `facts search/get/related/supersede`), `SchemaVersion` "1" → "2". Existing DBs must be deleted and re-mined (no migration framework, by design — see NFR-2).
+
+---
+
 ## File Layout
 
 ```
@@ -264,8 +426,12 @@ session-indexer/
 │   │   └── chunk.go         — []Message → []Chunk (split, filter, truncate)
 │   ├── embed/
 │   │   └── embed.go         — Ollama client, probe+model-check, float32 BLOB
-│   └── search/
-│       └── search.go        — exhaustive cosine; FTS5 fallback
+│   ├── search/
+│   │   └── search.go        — exhaustive cosine; FTS5 fallback; Stats
+│   ├── distill/
+│   │   └── distill.go       — Ollama generate client + orchestration (confidence gate, supersession)
+│   └── facts/
+│       └── facts.go         — read verbs: search (FTS5), get, related
 ├── docs/
 │   ├── requirements.md
 │   ├── use-cases.md

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -56,16 +56,46 @@ A Stop hook calls `session-indexer mine` before Claude Code closes the JSONL.
 ### FR-5: CLI interface
 
 ```
-session-indexer mine   <jsonl-path> --db <path>
-session-indexer search <query>      --db <path> [--limit N] [--json]
-session-indexer embed               --db <path>
-session-indexer stats               --db <path>
+session-indexer mine    <jsonl-path> --db <path>
+session-indexer search  <query>      --db <path> [--limit N] [--json]
+session-indexer embed                --db <path>
+session-indexer stats                --db <path>
+session-indexer distill              --db <path> [--threshold N]
+session-indexer facts search   <query>          --db <path> [--limit N] [--json] [--include-expired]
+session-indexer facts get      <id>             --db <path> [--json]
+session-indexer facts related  <id>             --db <path> [--json]
+session-indexer facts supersede <new-id> <old-id> --db <path>
 ```
 
 - `mine`: parse JSONL → insert chunks + generate embeddings. Idempotent.
 - `search`: embedding-first cosine (FTS5 fallback when Ollama unavailable). `--limit` default 5. `--json` for machine-readable output.
 - `embed`: backfill embeddings for chunks missing them (run after Ollama comes back online).
-- `stats`: report index state (sessions, chunks, pending embeddings, DB size).
+- `stats`: report index state (sessions, chunks, pending embeddings, current facts, pending distill, DB size).
+- `distill`: extract structured facts from mined chunks via an LLM call (see FR-6). `--threshold` default 0.7.
+- `facts search/get/related/supersede`: query and manually correct the distilled facts layer (see FR-7).
+
+### FR-6: Distill facts
+
+The tool must extract atomic subject-predicate-object facts from mined
+chunks via a manually-invoked LLM call, judging supersession against a
+bounded context of currently-valid facts about the same project.
+
+- Source: chunks not yet processed by `distill` (`distilled_chunks` progress marker, decoupled from produced facts — a chunk legitimately yields zero facts)
+- Extraction: a single Ollama `/api/generate` call per pending chunk, given the chunk plus a bounded set of current facts for supersession judgment
+- Confidence gate: a deterministic Go check (default threshold 0.7) against the model's self-reported confidence — advisory input to a hard check, not an LLM-enforced instruction
+- Supersession: judged automatically by the distill call; the model may only cite fact ids from the context it was given (validated in Go); a manual `facts supersede` command exists as an audit/override backstop
+- Idempotent: re-running `distill` skips chunks already marked, regardless of whether they produced facts
+- `distill` is a separate, manually-invoked subcommand — never hooks into `mine`'s two-phase run or its 50s deadline (see NFR-4)
+
+### FR-7: Query facts
+
+The tool must support read verbs over the distilled facts layer, and a
+manual override for supersession.
+
+- `facts search <query>`: FTS5 BM25 keyword search over `subject`/`predicate`/`object`; excludes tombstoned facts unless `--include-expired`
+- `facts get <id>`: a single fact plus its supersedes edges (incoming: older facts this one replaced; outgoing: the fact that replaced this one, if any)
+- `facts related <id>`: depth-1 union of incoming/outgoing supersedes neighbors — no BFS/deeper traversal in v1
+- `facts supersede <new-id> <old-id>`: manually tombstone `old-id` in favor of `new-id`; no-op (not an error) if `old-id` is already tombstoned
 
 ---
 
@@ -96,6 +126,7 @@ library dependencies. `go build` produces a portable binary.
 
 - `mine`: index one session in <30s on CPU (embedding 100 chunks via Ollama); must complete within 60s Stop hook timeout. Enforced internally via a 50s `context.Context` deadline. The mine run is split into two phases: (1) storing every chunk (fast, idempotent), then (2) embedding new chunks under the deadline. Chunks past the deadline are stored but flagged `Deferred` in `mine.Result` and left without an embedding row — backfill with `session-indexer embed`. Embed errors never abort a mine (counted as `Skipped`).
 - `search`: return results in <2s (FTS5 fallback), <5s (embedding cosine path). The fallback is per-term OR recall (not phrase match) and also triggers when the store has zero embeddings.
+- `distill` is explicitly exempt from `mine`'s determinism/latency budget — it is a manual command with no deadline, using `context.Background()` internally per chunk. A `/api/generate` call is slower than `/api/embed` (120s HTTP timeout vs 30s), and supersession judgment over a bounded fact context adds further latency that has no place inside a 60s Stop-hook window.
 
 ### NFR-5: Language support
 
@@ -123,3 +154,9 @@ both languages with equivalent quality.
 - Web UI or TUI
 - Cloud sync or backup
 - MCP server wrapper (can be added later as a thin layer)
+- Litopys's full 6-type node taxonomy (person/project/system/concept/event/lesson) — one flat `facts` table is enough for a single-project tool
+- Litopys's skill-detector / quarantine-and-promote human-review workflow — redundant with this repo's existing `dreaming`/`apply-dreaming` cycle
+- Cross-project facts
+- Per-fact embeddings (facts search is FTS5 BM25 only in v1 — facts are short, structured, and few per project)
+- Time-travel `--as-of` queries
+- BFS/multi-hop traversal for `facts related` (depth-1 only in v1)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -11,7 +11,7 @@ import (
 )
 
 // SchemaVersion is the schema the binary expects. Bump on any DDL change.
-const SchemaVersion = "1"
+const SchemaVersion = "2"
 
 //go:embed schema.sql
 var schemaSQL string
@@ -101,6 +101,127 @@ func ChunksWithoutEmbeddings(d *sql.DB) ([]PendingChunk, error) {
 			return nil, err
 		}
 		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// InsertFact inserts f. No dedup index — distillation isn't deterministic;
+// dedup/supersession is the distill LLM's job, not a unique constraint.
+// A zero SourceChunkID is stored as NULL (no source chunk), not as a
+// dangling foreign key to chunk id 0.
+func InsertFact(d *sql.DB, f internal.Fact) (id int64, err error) {
+	var sourceChunkID any
+	if f.SourceChunkID != 0 {
+		sourceChunkID = f.SourceChunkID
+	}
+	res, err := d.Exec(
+		`INSERT INTO facts
+		 (subject, predicate, object, confidence, source_chunk_id, session_date, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		f.Subject, f.Predicate, f.Object, f.Confidence, sourceChunkID, f.SessionDate, f.CreatedAt)
+	if err != nil {
+		return 0, fmt.Errorf("insert fact: %w", err)
+	}
+	id, _ = res.LastInsertId()
+	return id, nil
+}
+
+// MarkChunkDistilled records that chunkID has been through distill, even if
+// it yielded zero facts — otherwise a zero-fact chunk would be re-distilled
+// on every run.
+func MarkChunkDistilled(d *sql.DB, chunkID int64, at string) error {
+	_, err := d.Exec(
+		`INSERT OR REPLACE INTO distilled_chunks(chunk_id, distilled_at) VALUES (?, ?)`,
+		chunkID, at)
+	if err != nil {
+		return fmt.Errorf("mark chunk distilled: %w", err)
+	}
+	return nil
+}
+
+// PendingFactChunk is a chunk that has not yet been through distill.
+type PendingFactChunk struct {
+	ID          int64
+	Content     string
+	SessionDate string
+}
+
+// ChunksWithoutFacts lists chunks with no distilled_chunks row — the
+// distill analogue of ChunksWithoutEmbeddings. Decoupled from "has a facts
+// row" because a chunk legitimately yields zero facts.
+func ChunksWithoutFacts(d *sql.DB) ([]PendingFactChunk, error) {
+	rows, err := d.Query(
+		`SELECT c.id, c.content, c.session_date FROM chunks c
+		 LEFT JOIN distilled_chunks dc ON dc.chunk_id = c.id
+		 WHERE dc.chunk_id IS NULL`)
+	if err != nil {
+		return nil, fmt.Errorf("query pending facts: %w", err)
+	}
+	defer rows.Close()
+	var out []PendingFactChunk
+	for rows.Next() {
+		var p PendingFactChunk
+		if err := rows.Scan(&p.ID, &p.Content, &p.SessionDate); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// CurrentFacts returns up to limit non-tombstoned facts, most recent first —
+// the bounded context fed to the distiller for supersession judgment.
+func CurrentFacts(d *sql.DB, limit int) ([]internal.Fact, error) {
+	rows, err := d.Query(
+		`SELECT id, subject, predicate, object, confidence, source_chunk_id,
+		        session_date, created_at, until, superseded_by
+		 FROM facts WHERE until IS NULL ORDER BY created_at DESC LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query current facts: %w", err)
+	}
+	defer rows.Close()
+	return scanFacts(rows)
+}
+
+// SupersedeFact tombstones oldID in favor of newID, stamping until. Returns
+// false (no error) if oldID was already tombstoned — the call is a no-op,
+// not a failure. Shared by both auto-supersession (distill) and the manual
+// `facts supersede` command.
+func SupersedeFact(d *sql.DB, newID, oldID int64, until string) (bool, error) {
+	res, err := d.Exec(
+		`UPDATE facts SET until=?, superseded_by=? WHERE id=? AND until IS NULL`,
+		until, newID, oldID)
+	if err != nil {
+		return false, fmt.Errorf("supersede fact: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+// scanFacts drains rows into []internal.Fact. Callers own closing rows.
+func scanFacts(rows *sql.Rows) ([]internal.Fact, error) {
+	var out []internal.Fact
+	for rows.Next() {
+		var f internal.Fact
+		var sourceChunkID sql.NullInt64
+		var until sql.NullString
+		var supersededBy sql.NullInt64
+		if err := rows.Scan(&f.ID, &f.Subject, &f.Predicate, &f.Object, &f.Confidence,
+			&sourceChunkID, &f.SessionDate, &f.CreatedAt, &until, &supersededBy); err != nil {
+			return nil, err
+		}
+		if sourceChunkID.Valid {
+			f.SourceChunkID = sourceChunkID.Int64
+		}
+		if until.Valid {
+			u := until.String
+			f.Until = &u
+		}
+		if supersededBy.Valid {
+			s := supersededBy.Int64
+			f.SupersededBy = &s
+		}
+		out = append(out, f)
 	}
 	return out, rows.Err()
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"database/sql"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -124,5 +125,108 @@ func TestInsertEmbeddingAndPendingList(t *testing.T) {
 	pending, _ = ChunksWithoutEmbeddings(d)
 	if len(pending) != 0 {
 		t.Fatalf("pending after = %d, want 0", len(pending))
+	}
+}
+
+func TestInsertFactAndCurrentFacts(t *testing.T) {
+	d, _ := Open(tempDB(t))
+	defer d.Close()
+	id, err := InsertFact(d, internal.Fact{
+		Subject: "session-indexer", Predicate: "has", Object: "33 merged PRs",
+		Confidence: 0.9, SessionDate: "2026-07-01", CreatedAt: "2026-07-01T10:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("InsertFact: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("InsertFact returned id 0")
+	}
+	current, err := CurrentFacts(d, 10)
+	if err != nil {
+		t.Fatalf("CurrentFacts: %v", err)
+	}
+	if len(current) != 1 || current[0].ID != id {
+		t.Fatalf("CurrentFacts = %+v, want one fact with id %d", current, id)
+	}
+	if current[0].Until != nil {
+		t.Fatalf("Until = %v, want nil (currently valid)", *current[0].Until)
+	}
+}
+
+func TestChunksWithoutFactsExcludesDistilled(t *testing.T) {
+	d, _ := Open(tempDB(t))
+	defer d.Close()
+	c := internal.Chunk{SessionID: "s1", SessionDate: "2026-07-01", Role: "user",
+		MessageIndex: 0, ChunkIndex: 0, Content: "a chunk with nothing extractable", CreatedAt: "2026-07-01T10:00:00Z"}
+	id, _, _ := InsertChunk(d, c)
+	pending, err := ChunksWithoutFacts(d)
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending before = %+v err=%v, want 1", pending, err)
+	}
+	// Mark distilled with zero facts produced — must still drop from pending.
+	if err := MarkChunkDistilled(d, id, "2026-07-01T10:05:00Z"); err != nil {
+		t.Fatalf("MarkChunkDistilled: %v", err)
+	}
+	pending, err = ChunksWithoutFacts(d)
+	if err != nil || len(pending) != 0 {
+		t.Fatalf("pending after = %+v err=%v, want none (zero-fact chunk must not stay pending)", pending, err)
+	}
+}
+
+func TestSupersedeFactStampsUntilAndEdge(t *testing.T) {
+	d, _ := Open(tempDB(t))
+	defer d.Close()
+	oldID, _ := InsertFact(d, internal.Fact{Subject: "project", Predicate: "status", Object: "not started",
+		Confidence: 0.9, SessionDate: "2026-07-01", CreatedAt: "2026-07-01T10:00:00Z"})
+	newID, _ := InsertFact(d, internal.Fact{Subject: "project", Predicate: "status", Object: "in progress",
+		Confidence: 0.9, SessionDate: "2026-07-02", CreatedAt: "2026-07-02T10:00:00Z"})
+	changed, err := SupersedeFact(d, newID, oldID, "2026-07-02T10:00:00Z")
+	if err != nil {
+		t.Fatalf("SupersedeFact: %v", err)
+	}
+	if !changed {
+		t.Fatal("SupersedeFact reported changed=false, want true")
+	}
+	var until sql.NullString
+	var supersededBy sql.NullInt64
+	if err := d.QueryRow(`SELECT until, superseded_by FROM facts WHERE id=?`, oldID).
+		Scan(&until, &supersededBy); err != nil {
+		t.Fatalf("read supersede state: %v", err)
+	}
+	if !until.Valid || until.String != "2026-07-02T10:00:00Z" {
+		t.Fatalf("until = %+v, want stamped timestamp", until)
+	}
+	if !supersededBy.Valid || supersededBy.Int64 != newID {
+		t.Fatalf("superseded_by = %+v, want %d", supersededBy, newID)
+	}
+}
+
+func TestSupersedeFactNoOpWhenAlreadyTombstoned(t *testing.T) {
+	d, _ := Open(tempDB(t))
+	defer d.Close()
+	oldID, _ := InsertFact(d, internal.Fact{Subject: "s", Predicate: "p", Object: "o1",
+		Confidence: 0.9, SessionDate: "2026-07-01", CreatedAt: "2026-07-01T10:00:00Z"})
+	newID, _ := InsertFact(d, internal.Fact{Subject: "s", Predicate: "p", Object: "o2",
+		Confidence: 0.9, SessionDate: "2026-07-02", CreatedAt: "2026-07-02T10:00:00Z"})
+	otherID, _ := InsertFact(d, internal.Fact{Subject: "s", Predicate: "p", Object: "o3",
+		Confidence: 0.9, SessionDate: "2026-07-03", CreatedAt: "2026-07-03T10:00:00Z"})
+
+	if changed, err := SupersedeFact(d, newID, oldID, "2026-07-02T10:00:00Z"); err != nil || !changed {
+		t.Fatalf("first supersede: changed=%v err=%v, want true/nil", changed, err)
+	}
+	// Attempt to re-tombstone the same fact via a different superseder — no-op.
+	changed, err := SupersedeFact(d, otherID, oldID, "2026-07-03T10:00:00Z")
+	if err != nil {
+		t.Fatalf("second supersede: %v", err)
+	}
+	if changed {
+		t.Fatal("SupersedeFact on an already-tombstoned fact reported changed=true, want false (no-op)")
+	}
+	var supersededBy sql.NullInt64
+	if err := d.QueryRow(`SELECT superseded_by FROM facts WHERE id=?`, oldID).Scan(&supersededBy); err != nil {
+		t.Fatalf("read superseded_by: %v", err)
+	}
+	if !supersededBy.Valid || supersededBy.Int64 != newID {
+		t.Fatalf("superseded_by = %+v, want unchanged at %d (first supersede wins)", supersededBy, newID)
 	}
 }

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -2,7 +2,7 @@ CREATE TABLE meta (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
-INSERT INTO meta(key, value) VALUES ('schema_version', '1');
+INSERT INTO meta(key, value) VALUES ('schema_version', '2');
 
 CREATE TABLE chunks (
     id            INTEGER PRIMARY KEY,
@@ -36,3 +36,36 @@ CREATE TABLE embeddings (
 
 CREATE UNIQUE INDEX idx_chunks_dedup
     ON chunks(session_id, message_index, chunk_index);
+
+CREATE TABLE facts (
+    id              INTEGER PRIMARY KEY,
+    subject         TEXT    NOT NULL,
+    predicate       TEXT    NOT NULL,
+    object          TEXT    NOT NULL,
+    confidence      REAL    NOT NULL,
+    source_chunk_id INTEGER REFERENCES chunks(id) ON DELETE SET NULL,
+    session_date    TEXT    NOT NULL,
+    created_at      TEXT    NOT NULL,
+    until           TEXT,
+    superseded_by   INTEGER REFERENCES facts(id) ON DELETE SET NULL
+);
+
+CREATE VIRTUAL TABLE facts_fts USING fts5(
+    subject, predicate, object,
+    content='facts', content_rowid='id',
+    tokenize="unicode61 remove_diacritics 0"
+);
+
+CREATE TRIGGER facts_ai AFTER INSERT ON facts BEGIN
+    INSERT INTO facts_fts(rowid, subject, predicate, object)
+    VALUES (new.id, new.subject, new.predicate, new.object);
+END;
+CREATE TRIGGER facts_ad AFTER DELETE ON facts BEGIN
+    INSERT INTO facts_fts(facts_fts, rowid, subject, predicate, object)
+    VALUES ('delete', old.id, old.subject, old.predicate, old.object);
+END;
+
+CREATE TABLE distilled_chunks (
+    chunk_id     INTEGER PRIMARY KEY REFERENCES chunks(id) ON DELETE CASCADE,
+    distilled_at TEXT NOT NULL
+);

--- a/internal/distill/distill.go
+++ b/internal/distill/distill.go
@@ -1,0 +1,301 @@
+// Package distill extracts structured subject-predicate-object facts from
+// mined chunks via an Ollama chat/generate model, judging supersession
+// against a bounded context of currently-valid facts.
+package distill
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/valpere/session-indexer/internal"
+	"github.com/valpere/session-indexer/internal/db"
+)
+
+// Candidate is one fact proposed by the distiller for a single chunk.
+type Candidate struct {
+	Subject       string
+	Predicate     string
+	Object        string
+	Confidence    float64
+	SupersedesIDs []int64
+}
+
+// Distiller extracts fact candidates from a chunk and reports availability.
+type Distiller interface {
+	Available() bool
+	Distill(ctx context.Context, chunk string, existing []internal.Fact) ([]Candidate, error)
+}
+
+// Client is an Ollama-backed Distiller.
+type Client struct {
+	baseURL string
+	model   string
+	http    *http.Client
+}
+
+// NewClient returns a client configured from environment:
+//
+//	OLLAMA_HOST          — base URL (default: http://localhost:11434);
+//	                        if value has no scheme, http:// is prepended
+//	OLLAMA_DISTILL_MODEL — chat/generate model (default: qwen2.5:latest);
+//	                        distinct from OLLAMA_MODEL (embeddings) — must
+//	                        be pulled separately
+func NewClient() *Client {
+	baseURL := os.Getenv("OLLAMA_HOST")
+	if baseURL == "" {
+		baseURL = "http://localhost:11434"
+	} else if !strings.Contains(baseURL, "://") {
+		baseURL = "http://" + baseURL
+	}
+	model := os.Getenv("OLLAMA_DISTILL_MODEL")
+	if model == "" {
+		model = "qwen2.5:latest"
+	}
+	return NewClientURL(baseURL, model)
+}
+
+// NewClientURL builds a client against an arbitrary base URL (tests).
+func NewClientURL(baseURL, model string) *Client {
+	// 120s: generate is slower than embed's 30s — extraction over a full
+	// chunk plus supersession judgment is a larger completion than a
+	// single embedding vector.
+	return &Client{baseURL: baseURL, model: model, http: &http.Client{Timeout: 120 * time.Second}}
+}
+
+// Available probes GET /api/tags (2s) and checks the model is present.
+func (c *Client) Available() bool {
+	ctxClient := &http.Client{Timeout: 2 * time.Second}
+	resp, err := ctxClient.Get(c.baseURL + "/api/tags")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	var tags struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if json.NewDecoder(resp.Body).Decode(&tags) != nil {
+		return false
+	}
+	for _, m := range tags.Models {
+		if m.Name == c.model {
+			return true
+		}
+	}
+	return false
+}
+
+// distillResponse is the JSON shape the model is instructed to return.
+type distillResponse struct {
+	Facts []struct {
+		Subject       string  `json:"subject"`
+		Predicate     string  `json:"predicate"`
+		Object        string  `json:"object"`
+		Confidence    float64 `json:"confidence"`
+		SupersedesIDs []int64 `json:"supersedes_ids"`
+	} `json:"facts"`
+}
+
+// Distill returns fact candidates extracted from chunk via POST /api/generate.
+// The request is cancelled when ctx is done. Single attempt, no retry — a
+// failed chunk is left un-distilled for the next run, matching embed's
+// documented no-retry convention.
+func (c *Client) Distill(ctx context.Context, chunk string, existing []internal.Fact) ([]Candidate, error) {
+	prompt := buildPrompt(chunk, existing)
+	body, _ := json.Marshal(map[string]any{
+		"model":  c.model,
+		"prompt": prompt,
+		"stream": false,
+		"format": "json",
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/api/generate", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("ollama distill: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("ollama distill: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return nil, fmt.Errorf("ollama distill: status %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+	var out struct {
+		Response string `json:"response"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode distill response: %w", err)
+	}
+	if strings.TrimSpace(out.Response) == "" {
+		return nil, fmt.Errorf("ollama returned an empty response")
+	}
+	var parsed distillResponse
+	if err := json.Unmarshal([]byte(out.Response), &parsed); err != nil {
+		return nil, fmt.Errorf("decode facts json: %w", err)
+	}
+	candidates := make([]Candidate, 0, len(parsed.Facts))
+	for _, f := range parsed.Facts {
+		candidates = append(candidates, Candidate{
+			Subject:       f.Subject,
+			Predicate:     f.Predicate,
+			Object:        f.Object,
+			Confidence:    f.Confidence,
+			SupersedesIDs: f.SupersedesIDs,
+		})
+	}
+	return candidates, nil
+}
+
+const promptTemplate = `You extract atomic, durable facts from a single Claude Code conversation
+chunk. The chunk may be in English or Ukrainian or both — extract facts in
+the language they are stated; do not translate.
+
+Return ONLY JSON: {"facts":[{"subject":"...","predicate":"...","object":"...",
+"confidence":0.0,"supersedes_ids":[]}]}
+
+Each fact is a subject-predicate-object triple about the USER, the PROJECT,
+its CODE, DECISIONS, or CONVENTIONS. Extract only durable, reusable facts —
+not transient chit-chat, not restatements of the assistant's own reasoning.
+
+Confidence: explicitly stated as current truth → 0.9+; clearly implied →
+0.5-0.8; speculation/hedged/uncertain → below 0.5. Assign honestly —
+low-confidence facts will be discarded.
+
+You are given the project's CURRENT KNOWN FACTS (id + statement). If a fact
+you extract makes one of them false or out of date (status change, reversed
+decision, corrected value about the SAME subject), put that id in
+"supersedes_ids". Only use ids from this list. If nothing is superseded, use
+an empty array. Do not supersede a fact that is merely related but still true.
+
+CURRENT KNOWN FACTS:
+%s
+
+CHUNK:
+%s`
+
+// buildPrompt renders promptTemplate. Kept as plain string formatting, not
+// text/template — this codebase has no templating framework and one call
+// site doesn't justify adding one.
+func buildPrompt(chunk string, existing []internal.Fact) string {
+	var factsBlock strings.Builder
+	if len(existing) == 0 {
+		factsBlock.WriteString("(none yet)")
+	} else {
+		for _, f := range existing {
+			fmt.Fprintf(&factsBlock, " - [%d] %s | %s | %s\n", f.ID, f.Subject, f.Predicate, f.Object)
+		}
+	}
+	return fmt.Sprintf(promptTemplate, strings.TrimRight(factsBlock.String(), "\n"), chunk)
+}
+
+// Config controls a distill Run.
+type Config struct {
+	Threshold  float64 // minimum confidence to store a fact (default 0.7)
+	ContextCap int     // max current facts to feed the distiller for supersession judgment (default 200)
+}
+
+// Result summarizes a distill run.
+type Result struct {
+	ChunksDistilled int
+	FactsInserted   int
+	BelowThreshold  int
+	Superseded      int
+	Failed          int
+}
+
+// Run distills every chunk pending in d via cli, applying cfg's confidence
+// gate deterministically in Go (the model's self-reported confidence is
+// advisory input to this hard check, not the enforcement mechanism).
+//
+// Uses context.Background() internally per pending chunk's Distill call —
+// distill is a manual, non-time-boxed command, explicitly exempt from
+// mine's 50s/Stop-hook budget. The passed ctx still governs overall
+// cancellation (e.g. Ctrl-C) between chunks.
+func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, error) {
+	var res Result
+	pending, err := db.ChunksWithoutFacts(d)
+	if err != nil {
+		return res, err
+	}
+	for _, p := range pending {
+		if ctx.Err() != nil {
+			return res, ctx.Err()
+		}
+		existing, err := db.CurrentFacts(d, cfg.ContextCap+1)
+		if err != nil {
+			return res, err
+		}
+		// ContextCap exceeded: omit context and skip auto-supersession for
+		// this call — an oversized context would blow the prompt budget
+		// and the model has nothing reliable to judge supersession against.
+		contextExceeded := len(existing) > cfg.ContextCap
+		promptContext := existing
+		if contextExceeded {
+			promptContext = nil
+		}
+		allowedIDs := make(map[int64]bool, len(promptContext))
+		for _, f := range promptContext {
+			allowedIDs[f.ID] = true
+		}
+
+		candidates, err := cli.Distill(ctx, p.Content, promptContext)
+		if err != nil {
+			res.Failed++
+			continue // chunk not marked — retried on the next run
+		}
+		res.ChunksDistilled++
+
+		now := time.Now().UTC().Format(time.RFC3339)
+		for _, c := range candidates {
+			if c.Confidence < cfg.Threshold {
+				res.BelowThreshold++
+				continue
+			}
+			newID, err := db.InsertFact(d, internal.Fact{
+				Subject:       c.Subject,
+				Predicate:     c.Predicate,
+				Object:        c.Object,
+				Confidence:    c.Confidence,
+				SourceChunkID: p.ID,
+				SessionDate:   p.SessionDate,
+				CreatedAt:     now,
+			})
+			if err != nil {
+				res.Failed++
+				continue
+			}
+			res.FactsInserted++
+			if contextExceeded {
+				continue
+			}
+			for _, oldID := range c.SupersedesIDs {
+				// Safeguard: the model may only cite fact ids from the
+				// context it was actually given.
+				if !allowedIDs[oldID] {
+					continue
+				}
+				changed, err := db.SupersedeFact(d, newID, oldID, now)
+				if err == nil && changed {
+					res.Superseded++
+				}
+			}
+		}
+		if err := db.MarkChunkDistilled(d, p.ID, now); err != nil {
+			return res, err
+		}
+	}
+	return res, nil
+}

--- a/internal/distill/distill.go
+++ b/internal/distill/distill.go
@@ -251,7 +251,10 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 			allowedIDs[f.ID] = true
 		}
 
-		candidates, err := cli.Distill(ctx, p.Content, promptContext)
+		// context.Background(), not ctx: distill is exempt from the
+		// caller's deadline (see doc comment above) — ctx only governs
+		// cancellation between chunks, checked via ctx.Err() above.
+		candidates, err := cli.Distill(context.Background(), p.Content, promptContext)
 		if err != nil {
 			res.Failed++
 			continue // chunk not marked — retried on the next run
@@ -259,6 +262,12 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 		res.ChunksDistilled++
 
 		now := time.Now().UTC().Format(time.RFC3339)
+		// storeFailed tracks whether any candidate for this chunk hit a DB
+		// error (InsertFact/SupersedeFact) rather than a confidence-gate
+		// discard. On a store failure the chunk is left unmarked so it's
+		// retried on the next run, same as a Distill call failure above —
+		// a transient DB error must not permanently drop a candidate fact.
+		var storeFailed bool
 		for _, c := range candidates {
 			if c.Confidence < cfg.Threshold {
 				res.BelowThreshold++
@@ -275,6 +284,7 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 			})
 			if err != nil {
 				res.Failed++
+				storeFailed = true
 				continue
 			}
 			res.FactsInserted++
@@ -288,10 +298,18 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 					continue
 				}
 				changed, err := db.SupersedeFact(d, newID, oldID, now)
-				if err == nil && changed {
+				if err != nil {
+					res.Failed++
+					storeFailed = true
+					continue
+				}
+				if changed {
 					res.Superseded++
 				}
 			}
+		}
+		if storeFailed {
+			continue // chunk not marked — retried on the next run
 		}
 		if err := db.MarkChunkDistilled(d, p.ID, now); err != nil {
 			return res, err

--- a/internal/distill/distill_test.go
+++ b/internal/distill/distill_test.go
@@ -110,6 +110,8 @@ func (s *stubDistiller) Distill(_ context.Context, chunk string, existing []inte
 	return f(chunk, existing)
 }
 
+// Package-level counter, safe only because no test in this suite (or this
+// codebase generally) uses t.Parallel() — revisit if that ever changes.
 var seedChunkCounter int
 
 func seedChunk(t *testing.T, d *sql.DB, content, sessionDate string) int64 {
@@ -234,6 +236,81 @@ func TestRunLeavesChunkOnError(t *testing.T) {
 	if err != nil || len(pending) != 1 {
 		t.Fatalf("pending after failed chunk = %+v err=%v, want 1 (must be retried later)", pending, err)
 	}
+}
+
+// TestRunLeavesChunkOnInsertFactError verifies that a DB-level failure
+// storing a candidate fact (not a Distill call failure) also leaves the
+// chunk unmarked, consistent with the "chunk not marked — retried on the
+// next run" contract used for Distill call failures. A transient DB error
+// must not permanently drop a fact candidate that was successfully extracted.
+func TestRunLeavesChunkOnInsertFactError(t *testing.T) {
+	d := openTestDB(t)
+	seedChunk(t, d, "chunk whose fact fails to store", "2026-07-01")
+	// Drop facts_fts (the trigger target for INSERT INTO facts) so
+	// InsertFact fails deterministically inside Run, without touching
+	// production code to inject a fault. CurrentFacts (a plain SELECT on
+	// facts, called earlier in the loop) is unaffected.
+	if _, err := d.Exec(`DROP TABLE facts_fts`); err != nil {
+		t.Fatalf("drop facts_fts table: %v", err)
+	}
+	cli := &stubDistiller{avail: true, calls: []func(string, []internal.Fact) ([]Candidate, error){
+		func(string, []internal.Fact) ([]Candidate, error) {
+			return []Candidate{{Subject: "s", Predicate: "p", Object: "o", Confidence: 0.9}}, nil
+		},
+	}}
+	res, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Failed != 1 {
+		t.Fatalf("res.Failed = %d, want 1", res.Failed)
+	}
+	if res.FactsInserted != 0 {
+		t.Fatalf("res.FactsInserted = %d, want 0", res.FactsInserted)
+	}
+	pending, err := db.ChunksWithoutFacts(d)
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending after InsertFact failure = %+v err=%v, want 1 (must be retried later, not permanently dropped)", pending, err)
+	}
+}
+
+// TestRunUsesBackgroundContextForDistillCall verifies that Distill is
+// always called with a context independent of Run's outer ctx — distill is
+// exempt from the caller's deadline by design; the outer ctx only governs
+// cancellation between chunks. A caller passing an already-past-deadline
+// (but not yet Err()-returning at the loop-top check) context must not leak
+// that deadline into the per-chunk Distill call.
+func TestRunUsesBackgroundContextForDistillCall(t *testing.T) {
+	d := openTestDB(t)
+	seedChunk(t, d, "chunk checking context independence", "2026-07-01")
+	var gotCtx context.Context
+	cli := &stubDistiller{avail: true, calls: []func(string, []internal.Fact) ([]Candidate, error){
+		func(string, []internal.Fact) ([]Candidate, error) {
+			return nil, nil
+		},
+	}}
+	// Wrap stubDistiller's Distill to capture the ctx it actually receives.
+	capturing := &capturingDistiller{inner: cli, captured: &gotCtx}
+	if _, err := Run(context.Background(), d, capturing, Config{Threshold: 0.7, ContextCap: 200}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if gotCtx == nil {
+		t.Fatal("Distill was never called")
+	}
+	if gotCtx != context.Background() {
+		t.Fatalf("Distill received a ctx other than context.Background(): %v", gotCtx)
+	}
+}
+
+type capturingDistiller struct {
+	inner    Distiller
+	captured *context.Context
+}
+
+func (c *capturingDistiller) Available() bool { return c.inner.Available() }
+func (c *capturingDistiller) Distill(ctx context.Context, chunk string, existing []internal.Fact) ([]Candidate, error) {
+	*c.captured = ctx
+	return c.inner.Distill(ctx, chunk, existing)
 }
 
 func TestRunRejectsSupersedeIDOutsideContext(t *testing.T) {

--- a/internal/distill/distill_test.go
+++ b/internal/distill/distill_test.go
@@ -1,0 +1,257 @@
+package distill
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/valpere/session-indexer/internal"
+	"github.com/valpere/session-indexer/internal/db"
+)
+
+func TestAvailableTrueWhenModelPresent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"models":[{"name":"qwen2.5:latest"}]}`))
+	}))
+	defer srv.Close()
+	c := NewClientURL(srv.URL, "qwen2.5:latest")
+	if !c.Available() {
+		t.Fatal("Available() = false, want true")
+	}
+}
+
+func TestAvailableFalseWhenModelMissing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"models":[{"name":"llama3:latest"}]}`))
+	}))
+	defer srv.Close()
+	c := NewClientURL(srv.URL, "qwen2.5:latest")
+	if c.Available() {
+		t.Fatal("Available() = true, want false (model absent)")
+	}
+}
+
+func TestDistillParsesFacts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"response":"{\"facts\":[{\"subject\":\"session-indexer\",\"predicate\":\"has\",\"object\":\"33 merged PRs\",\"confidence\":0.95,\"supersedes_ids\":[]}]}"}`))
+	}))
+	defer srv.Close()
+	c := NewClientURL(srv.URL, "qwen2.5:latest")
+	candidates, err := c.Distill(context.Background(), "chunk text", nil)
+	if err != nil {
+		t.Fatalf("Distill: %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].Subject != "session-indexer" {
+		t.Fatalf("candidates = %+v", candidates)
+	}
+	if candidates[0].Confidence != 0.95 {
+		t.Fatalf("confidence = %v, want 0.95", candidates[0].Confidence)
+	}
+}
+
+func TestDistillSurfacesHTTPStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"model loading failed"}`))
+	}))
+	defer srv.Close()
+	c := NewClientURL(srv.URL, "qwen2.5:latest")
+	_, err := c.Distill(context.Background(), "chunk", nil)
+	if err == nil {
+		t.Fatal("expected error for 500 response, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("error should mention status 500, got: %v", err)
+	}
+}
+
+func TestDistillRespectsContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+	c := NewClientURL(srv.URL, "qwen2.5:latest")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+	_, err := c.Distill(ctx, "chunk", nil)
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+}
+
+func TestDistillEmptyResponseGuard(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"response":""}`))
+	}))
+	defer srv.Close()
+	c := NewClientURL(srv.URL, "qwen2.5:latest")
+	_, err := c.Distill(context.Background(), "chunk", nil)
+	if err == nil {
+		t.Fatal("expected error for empty response, got nil")
+	}
+}
+
+// stubDistiller is a Distiller test double driven by a queue of canned
+// responses, one per Distill call (matching call order).
+type stubDistiller struct {
+	avail bool
+	calls []func(chunk string, existing []internal.Fact) ([]Candidate, error)
+	n     int
+}
+
+func (s *stubDistiller) Available() bool { return s.avail }
+func (s *stubDistiller) Distill(_ context.Context, chunk string, existing []internal.Fact) ([]Candidate, error) {
+	f := s.calls[s.n]
+	s.n++
+	return f(chunk, existing)
+}
+
+var seedChunkCounter int
+
+func seedChunk(t *testing.T, d *sql.DB, content, sessionDate string) int64 {
+	t.Helper()
+	c := internal.Chunk{SessionID: "s1", SessionDate: sessionDate, Role: "user",
+		MessageIndex: seedChunkCounter, ChunkIndex: 0, Content: content, CreatedAt: sessionDate + "T10:00:00Z"}
+	seedChunkCounter++
+	id, inserted, err := db.InsertChunk(d, c)
+	if err != nil || !inserted {
+		t.Fatalf("seedChunk: id=%d inserted=%v err=%v", id, inserted, err)
+	}
+	return id
+}
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	d, err := db.Open(filepath.Join(t.TempDir(), "sessions.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+func TestRunAppliesConfidenceGate(t *testing.T) {
+	d := openTestDB(t)
+	seedChunk(t, d, "chunk one content here", "2026-07-01")
+	cli := &stubDistiller{avail: true, calls: []func(string, []internal.Fact) ([]Candidate, error){
+		func(string, []internal.Fact) ([]Candidate, error) {
+			return []Candidate{
+				{Subject: "s", Predicate: "p", Object: "high", Confidence: 0.9},
+				{Subject: "s", Predicate: "p", Object: "low", Confidence: 0.4},
+			}, nil
+		},
+	}}
+	res, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.FactsInserted != 1 || res.BelowThreshold != 1 {
+		t.Fatalf("res = %+v, want FactsInserted=1 BelowThreshold=1", res)
+	}
+}
+
+func TestRunAppliesSupersession(t *testing.T) {
+	d := openTestDB(t)
+	// First chunk establishes a fact.
+	seedChunk(t, d, "old status chunk", "2026-07-01")
+	cli := &stubDistiller{avail: true, calls: []func(string, []internal.Fact) ([]Candidate, error){
+		func(string, []internal.Fact) ([]Candidate, error) {
+			return []Candidate{{Subject: "project", Predicate: "status", Object: "not started", Confidence: 0.9}}, nil
+		},
+	}}
+	if _, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200}); err != nil {
+		t.Fatalf("Run 1: %v", err)
+	}
+	existing, err := db.CurrentFacts(d, 200)
+	if err != nil || len(existing) != 1 {
+		t.Fatalf("CurrentFacts after run 1: %v err=%v", existing, err)
+	}
+	oldID := existing[0].ID
+
+	// Second chunk supersedes the first, citing the id it was given.
+	seedChunk(t, d, "new status chunk", "2026-07-02")
+	cli2 := &stubDistiller{avail: true, calls: []func(string, []internal.Fact) ([]Candidate, error){
+		func(_ string, given []internal.Fact) ([]Candidate, error) {
+			if len(given) != 1 || given[0].ID != oldID {
+				t.Fatalf("expected context to contain old fact id %d, got %+v", oldID, given)
+			}
+			return []Candidate{{Subject: "project", Predicate: "status", Object: "in progress",
+				Confidence: 0.9, SupersedesIDs: []int64{oldID}}}, nil
+		},
+	}}
+	res, err := Run(context.Background(), d, cli2, Config{Threshold: 0.7, ContextCap: 200})
+	if err != nil {
+		t.Fatalf("Run 2: %v", err)
+	}
+	if res.Superseded != 1 {
+		t.Fatalf("res.Superseded = %d, want 1", res.Superseded)
+	}
+	current, err := db.CurrentFacts(d, 200)
+	if err != nil || len(current) != 1 || current[0].Object != "in progress" {
+		t.Fatalf("current facts after supersession = %+v err=%v", current, err)
+	}
+}
+
+func TestRunMarksChunkOnZeroFacts(t *testing.T) {
+	d := openTestDB(t)
+	seedChunk(t, d, "chunk with nothing extractable", "2026-07-01")
+	cli := &stubDistiller{avail: true, calls: []func(string, []internal.Fact) ([]Candidate, error){
+		func(string, []internal.Fact) ([]Candidate, error) { return nil, nil },
+	}}
+	res, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.ChunksDistilled != 1 || res.FactsInserted != 0 {
+		t.Fatalf("res = %+v, want ChunksDistilled=1 FactsInserted=0", res)
+	}
+	pending, err := db.ChunksWithoutFacts(d)
+	if err != nil || len(pending) != 0 {
+		t.Fatalf("pending after zero-fact chunk = %+v err=%v, want none (must not re-distill)", pending, err)
+	}
+}
+
+func TestRunLeavesChunkOnError(t *testing.T) {
+	d := openTestDB(t)
+	seedChunk(t, d, "chunk that fails distillation", "2026-07-01")
+	cli := &stubDistiller{avail: true, calls: []func(string, []internal.Fact) ([]Candidate, error){
+		func(string, []internal.Fact) ([]Candidate, error) {
+			return nil, context.DeadlineExceeded
+		},
+	}}
+	res, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Failed != 1 {
+		t.Fatalf("res.Failed = %d, want 1", res.Failed)
+	}
+	pending, err := db.ChunksWithoutFacts(d)
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending after failed chunk = %+v err=%v, want 1 (must be retried later)", pending, err)
+	}
+}
+
+func TestRunRejectsSupersedeIDOutsideContext(t *testing.T) {
+	d := openTestDB(t)
+	seedChunk(t, d, "chunk citing an id it was never given", "2026-07-01")
+	cli := &stubDistiller{avail: true, calls: []func(string, []internal.Fact) ([]Candidate, error){
+		func(string, []internal.Fact) ([]Candidate, error) {
+			// existing is empty (no prior facts), yet the model claims to
+			// supersede id 999 — must be rejected, not applied blindly.
+			return []Candidate{{Subject: "s", Predicate: "p", Object: "o",
+				Confidence: 0.9, SupersedesIDs: []int64{999}}}, nil
+		},
+	}}
+	res, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Superseded != 0 {
+		t.Fatalf("res.Superseded = %d, want 0 (id 999 was never in the given context)", res.Superseded)
+	}
+}

--- a/internal/facts/facts.go
+++ b/internal/facts/facts.go
@@ -1,0 +1,148 @@
+// Package facts provides read verbs over the distilled facts layer: keyword
+// search, single-fact lookup with supersedes edges, and depth-1 related
+// facts. Pure functions over *sql.DB — no shared framework exists in this
+// codebase, so none is invented here.
+package facts
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/valpere/session-indexer/internal"
+)
+
+// Search returns up to limit facts matching query via FTS5 BM25 over
+// facts_fts. Tombstoned facts are excluded unless includeExpired is true.
+func Search(d *sql.DB, query string, limit int, includeExpired bool) ([]internal.Fact, error) {
+	match := ftsMatchExpr(query)
+	if match == "" {
+		return nil, nil // no usable terms; caller prints "(no results)"
+	}
+	q := `SELECT f.id, f.subject, f.predicate, f.object, f.confidence,
+	             f.source_chunk_id, f.session_date, f.created_at, f.until, f.superseded_by
+	      FROM facts f JOIN facts_fts ON f.id = facts_fts.rowid
+	      WHERE facts_fts MATCH ?`
+	if !includeExpired {
+		q += ` AND f.until IS NULL`
+	}
+	q += ` ORDER BY bm25(facts_fts) LIMIT ?`
+	rows, err := d.Query(q, match, limit)
+	if err != nil {
+		return nil, fmt.Errorf("facts fts query: %w", err)
+	}
+	defer rows.Close()
+	return scanFacts(rows)
+}
+
+// Get returns fact id along with its supersedes edges: outgoing is what
+// this fact points to (superseded_by), incoming is the set of older facts
+// whose superseded_by references id.
+func Get(d *sql.DB, id int64) (fact internal.Fact, incoming, outgoing []internal.Fact, err error) {
+	row := d.QueryRow(
+		`SELECT id, subject, predicate, object, confidence,
+		        source_chunk_id, session_date, created_at, until, superseded_by
+		 FROM facts WHERE id=?`, id)
+	fact, err = scanFactRow(row)
+	if err != nil {
+		return internal.Fact{}, nil, nil, err
+	}
+
+	incRows, err := d.Query(
+		`SELECT id, subject, predicate, object, confidence,
+		        source_chunk_id, session_date, created_at, until, superseded_by
+		 FROM facts WHERE superseded_by=?`, id)
+	if err != nil {
+		return internal.Fact{}, nil, nil, fmt.Errorf("query incoming: %w", err)
+	}
+	defer incRows.Close()
+	incoming, err = scanFacts(incRows)
+	if err != nil {
+		return internal.Fact{}, nil, nil, err
+	}
+
+	if fact.SupersededBy != nil {
+		outRows, err := d.Query(
+			`SELECT id, subject, predicate, object, confidence,
+			        source_chunk_id, session_date, created_at, until, superseded_by
+			 FROM facts WHERE id=?`, *fact.SupersededBy)
+		if err != nil {
+			return internal.Fact{}, nil, nil, fmt.Errorf("query outgoing: %w", err)
+		}
+		defer outRows.Close()
+		outgoing, err = scanFacts(outRows)
+		if err != nil {
+			return internal.Fact{}, nil, nil, err
+		}
+	}
+	return fact, incoming, outgoing, nil
+}
+
+// Related returns the depth-1 union of id's incoming and outgoing supersedes
+// neighbors. No BFS/depth parameter in v1 — YAGNI until a real need surfaces.
+func Related(d *sql.DB, id int64) ([]internal.Fact, error) {
+	_, incoming, outgoing, err := Get(d, id)
+	if err != nil {
+		return nil, err
+	}
+	return append(incoming, outgoing...), nil
+}
+
+// ftsMatchExpr builds an OR of quoted terms from the query for keyword
+// recall — the same per-term-OR approach as internal/search.ftsMatchExpr
+// (unexported there; reimplemented here rather than shared, matching this
+// codebase's no-shared-framework convention).
+func ftsMatchExpr(query string) string {
+	var terms []string
+	for _, w := range strings.Fields(query) {
+		terms = append(terms, `"`+strings.ReplaceAll(w, `"`, `""`)+`"`)
+	}
+	return strings.Join(terms, " OR ")
+}
+
+// scanFactRow scans a single *sql.Row into an internal.Fact.
+func scanFactRow(row *sql.Row) (internal.Fact, error) {
+	var f internal.Fact
+	var sourceChunkID sql.NullInt64
+	var until sql.NullString
+	var supersededBy sql.NullInt64
+	err := row.Scan(&f.ID, &f.Subject, &f.Predicate, &f.Object, &f.Confidence,
+		&sourceChunkID, &f.SessionDate, &f.CreatedAt, &until, &supersededBy)
+	if err != nil {
+		return internal.Fact{}, fmt.Errorf("scan fact: %w", err)
+	}
+	applyNullable(&f, sourceChunkID, until, supersededBy)
+	return f, nil
+}
+
+// scanFacts drains rows into []internal.Fact. Callers own closing rows.
+func scanFacts(rows *sql.Rows) ([]internal.Fact, error) {
+	var out []internal.Fact
+	for rows.Next() {
+		var f internal.Fact
+		var sourceChunkID sql.NullInt64
+		var until sql.NullString
+		var supersededBy sql.NullInt64
+		if err := rows.Scan(&f.ID, &f.Subject, &f.Predicate, &f.Object, &f.Confidence,
+			&sourceChunkID, &f.SessionDate, &f.CreatedAt, &until, &supersededBy); err != nil {
+			return nil, err
+		}
+		applyNullable(&f, sourceChunkID, until, supersededBy)
+		out = append(out, f)
+	}
+	return out, rows.Err()
+}
+
+func applyNullable(f *internal.Fact, sourceChunkID sql.NullInt64, until sql.NullString, supersededBy sql.NullInt64) {
+	if sourceChunkID.Valid {
+		f.SourceChunkID = sourceChunkID.Int64
+	}
+	if until.Valid {
+		u := until.String
+		f.Until = &u
+	}
+	if supersededBy.Valid {
+		s := supersededBy.Int64
+		f.SupersededBy = &s
+	}
+}

--- a/internal/facts/facts_test.go
+++ b/internal/facts/facts_test.go
@@ -1,0 +1,145 @@
+package facts
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/valpere/session-indexer/internal"
+	"github.com/valpere/session-indexer/internal/db"
+)
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	d, err := db.Open(filepath.Join(t.TempDir(), "sessions.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+func insertFact(t *testing.T, d *sql.DB, subject, predicate, object string) int64 {
+	t.Helper()
+	id, err := db.InsertFact(d, internal.Fact{
+		Subject: subject, Predicate: predicate, Object: object,
+		Confidence: 0.9, SessionDate: "2026-07-01", CreatedAt: "2026-07-01T10:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("InsertFact: %v", err)
+	}
+	return id
+}
+
+func TestSearchEmptyStore(t *testing.T) {
+	d := openTestDB(t)
+	res, err := Search(d, "anything", 5, false)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("results = %+v, want none on empty store", res)
+	}
+}
+
+func TestSearchExcludesExpiredByDefault(t *testing.T) {
+	d := openTestDB(t)
+	oldID := insertFact(t, d, "project", "status", "not started")
+	newID := insertFact(t, d, "project", "status", "in progress")
+	if _, err := db.SupersedeFact(d, newID, oldID, "2026-07-02T10:00:00Z"); err != nil {
+		t.Fatalf("SupersedeFact: %v", err)
+	}
+	res, err := Search(d, "status", 5, false)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	for _, f := range res {
+		if f.ID == oldID {
+			t.Fatalf("expired fact %d present in default search results: %+v", oldID, res)
+		}
+	}
+	found := false
+	for _, f := range res {
+		if f.ID == newID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("current fact %d missing from search results: %+v", newID, res)
+	}
+}
+
+func TestSearchIncludeExpired(t *testing.T) {
+	d := openTestDB(t)
+	oldID := insertFact(t, d, "project", "status", "not started")
+	newID := insertFact(t, d, "project", "status", "in progress")
+	if _, err := db.SupersedeFact(d, newID, oldID, "2026-07-02T10:00:00Z"); err != nil {
+		t.Fatalf("SupersedeFact: %v", err)
+	}
+	res, err := Search(d, "status", 5, true)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	found := false
+	for _, f := range res {
+		if f.ID == oldID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expired fact %d missing with includeExpired=true: %+v", oldID, res)
+	}
+}
+
+func TestGetReturnsSupersedesEdges(t *testing.T) {
+	d := openTestDB(t)
+	oldID := insertFact(t, d, "project", "status", "not started")
+	newID := insertFact(t, d, "project", "status", "in progress")
+	if _, err := db.SupersedeFact(d, newID, oldID, "2026-07-02T10:00:00Z"); err != nil {
+		t.Fatalf("SupersedeFact: %v", err)
+	}
+
+	oldFact, oldIncoming, oldOutgoing, err := Get(d, oldID)
+	if err != nil {
+		t.Fatalf("Get(old): %v", err)
+	}
+	if oldFact.Until == nil {
+		t.Fatal("old fact Until is nil, want a tombstone timestamp")
+	}
+	if len(oldIncoming) != 0 {
+		t.Fatalf("old fact incoming = %+v, want none", oldIncoming)
+	}
+	if len(oldOutgoing) != 1 || oldOutgoing[0].ID != newID {
+		t.Fatalf("old fact outgoing = %+v, want [newID=%d]", oldOutgoing, newID)
+	}
+
+	newFact, newIncoming, newOutgoing, err := Get(d, newID)
+	if err != nil {
+		t.Fatalf("Get(new): %v", err)
+	}
+	if newFact.Until != nil {
+		t.Fatalf("new fact Until = %v, want nil (currently valid)", *newFact.Until)
+	}
+	if len(newIncoming) != 1 || newIncoming[0].ID != oldID {
+		t.Fatalf("new fact incoming = %+v, want [oldID=%d]", newIncoming, oldID)
+	}
+	if len(newOutgoing) != 0 {
+		t.Fatalf("new fact outgoing = %+v, want none", newOutgoing)
+	}
+}
+
+func TestRelatedDepth1(t *testing.T) {
+	d := openTestDB(t)
+	oldID := insertFact(t, d, "project", "status", "not started")
+	newID := insertFact(t, d, "project", "status", "in progress")
+	if _, err := db.SupersedeFact(d, newID, oldID, "2026-07-02T10:00:00Z"); err != nil {
+		t.Fatalf("SupersedeFact: %v", err)
+	}
+	related, err := Related(d, newID)
+	if err != nil {
+		t.Fatalf("Related: %v", err)
+	}
+	if len(related) != 1 || related[0].ID != oldID {
+		t.Fatalf("Related(new) = %+v, want [oldID=%d]", related, oldID)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -137,13 +137,15 @@ func cosine(a, b []float32) float64 {
 
 // Stats describes index state for the stats subcommand.
 type Stats struct {
-	Sessions int
-	Chunks   int
-	Embedded int
-	Pending  int
-	Oldest   string
-	Newest   string
-	DBSize   string // human-readable on-disk size, e.g. "4.2 MB"
+	Sessions       int
+	Chunks         int
+	Embedded       int
+	Pending        int
+	Facts          int // currently valid (non-tombstoned) facts
+	PendingDistill int // chunks not yet through distill
+	Oldest         string
+	Newest         string
+	DBSize         string // human-readable on-disk size, e.g. "4.2 MB"
 }
 
 // GetStats reports index counts, date range, and on-disk DB size. dbPath is
@@ -161,6 +163,14 @@ func GetStats(d *sql.DB, dbPath string) (Stats, error) {
 		return s, err
 	}
 	s.Pending = s.Chunks - s.Embedded
+	if err := q(`SELECT COUNT(*) FROM facts WHERE until IS NULL`, &s.Facts); err != nil {
+		return s, err
+	}
+	var distilled int
+	if err := q(`SELECT COUNT(*) FROM distilled_chunks`, &distilled); err != nil {
+		return s, err
+	}
+	s.PendingDistill = s.Chunks - distilled
 	// Date range is best-effort; empty store leaves these blank.
 	var oldest, newest sql.NullString
 	_ = d.QueryRow(`SELECT MIN(session_date), MAX(session_date) FROM chunks`).Scan(&oldest, &newest)

--- a/internal/types.go
+++ b/internal/types.go
@@ -19,3 +19,18 @@ type SearchResult struct {
 	Content     string
 	Score       float64 // cosine similarity, or BM25 (negated) in fallback
 }
+
+// Fact is one distilled subject-predicate-object claim, optionally
+// tombstoned by a newer fact that supersedes it.
+type Fact struct {
+	ID            int64
+	Subject       string
+	Predicate     string
+	Object        string
+	Confidence    float64
+	SourceChunkID int64
+	SessionDate   string
+	CreatedAt     string  // RFC3339, distilled-at
+	Until         *string // tombstone timestamp; nil = currently valid
+	SupersededBy  *int64  // id of the fact that superseded this one
+}


### PR DESCRIPTION
## Summary

Ports a scoped-down version of litopys's `supersedes`/tombstone concept directly into session-indexer. Closes a real gap: stale project facts currently surface only during periodic dreaming/apply-dreaming review, sometimes weeks after they became false. A facts layer distilled automatically from sessions catches this class of drift at index time.

- **New `distill` subcommand** — manual, LLM-extracts subject-predicate-object facts from mined chunks via Ollama `/api/generate`. Never wired into `mine`'s 50s Stop-hook deadline — separate command, `context.Background()`, 120s HTTP timeout.
- **New `facts search/get/related/supersede`** — read verbs over the distilled layer (FTS5 BM25 search, supersedes-edge lookup, depth-1 related, manual audit/override backstop).
- **Schema bump "1" → "2"** — three new tables (`facts`, `facts_fts` + triggers, `distilled_chunks`). Existing DBs must be deleted and re-mined (no migration framework, per this project's existing NFR-2 contract).

### Key design decisions (full rationale in `docs/architecture.md`'s new "Facts Layer" section)

- Flat `facts` table, no per-type node taxonomy, no separate edges table — `supersedes` is the only relation, captured by a self-referential `superseded_by` column.
- Confidence gate (default 0.7) is a **deterministic Go check**, not an LLM-enforced instruction — a deliberate deviation from litopys.
- Supersession is judged automatically by the distill LLM call given a bounded context of current facts, safeguarded by validating cited fact ids against what was actually provided; `facts supersede` exists as a manual audit/override backstop.

`internal/distill/` (new) mirrors `internal/embed/` line for line; `internal/facts/` (new) mirrors `internal/search/`'s shape — matching this codebase's existing conventions throughout.

## Test plan

- [x] 21 new tests across `db_test.go`/`distill_test.go`/`facts_test.go` — 62 total, `-race` clean, 75–84% coverage on the new packages
- [x] `go build && go vet && gofmt -l . && go test ./...` all green
- [x] **Verified end-to-end against a real Ollama instance** (not just unit tests): extraction, confidence gate, auto-supersession, manual override via `facts supersede`, `--include-expired` filtering, idempotent re-run (0 chunks on second `distill`), graceful degradation when the configured model is missing, and v1-DB schema-version rejection all behaved as designed
- [x] Docs updated: `docs/requirements.md` (FR-6/FR-7, NFR-4, Out of Scope), `docs/architecture.md` (schema + new Facts Layer section + changelog), `README.md` (Usage, env var, Iron-Law querying-discipline section), `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)