### PR TITLE
docs: /recall is now a user-level skill, not per-project

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ ollama pull bge-m3:latest
 # 3. Wire the hooks into your project (one-time setup)
 #    Copy session-index.sh + session-recall.sh → .claude/hooks/
 #    Update .claude/settings.local.json with Stop + SessionStart entries
-#    Install /recall skill → .claude/skills/session-recall/SKILL.md
+#    /recall is a user-level skill (~/.claude/skills/session-recall/, symlinked
+#    from ~/wrk/common/skills/session-recall/) — no per-project install needed.
 #    See "Hook Setup" below for the exact steps.
 
 # 4. End a Claude Code session — Stop hook mines it into .claude/sessions.db

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -440,16 +440,13 @@ session-indexer/
 │   │                            sessions.db, session-log.md, settings.local.json,
 │   │                            and telemetry.jsonl are gitignored (per-machine
 │   │                            state, see .gitignore)
-│   │                            Canonical source: ~/wrk/common/skills/session-recall/
 │   ├── hooks/
 │   │   ├── session-end.sh    — Stop: LLM summary → session-log.md
 │   │   ├── session-index.sh  — Stop: mine JSONL → sessions.db
 │   │   ├── session-last.sh   — SessionStart: inject last summary
 │   │   ├── session-recall.sh — SessionStart: semantic context injection
 │   │   └── _lib/hook-common.sh  — logging + shared session-log.md rotation (jq/bash, no python3)
-│   ├── skills/
-│   │   └── session-recall/SKILL.md  — /recall <query> skill + orchestrator subagent-prep section
-│   └── settings.local.json
+│   ├── settings.local.json
 ├── .gitignore
 ├── go.mod                   — go 1.26.5
 └── Makefile
@@ -549,7 +546,9 @@ Relevant past sessions (semantic search):
 ## Orchestrator / Subagent Recall Pattern
 
 Subagents spawned via the Agent tool start cold — no `SessionStart` hook, no
-shared context. `.claude/skills/session-recall/SKILL.md` documents the same
+shared context. The user-level `/recall` skill
+(`~/.claude/skills/session-recall/SKILL.md`, symlinked from
+`~/wrk/common/skills/session-recall/SKILL.md`) documents the same
 `search` subcommand used by `/recall`, but for a different caller: the
 *orchestrator*, invoking it directly before spawning a subagent whose task
 benefits from project history (rather than through the Skill tool):

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -106,7 +106,7 @@ work — without Val having to remember to ask.
 **Trigger:** Val types `/recall <query>` in Claude Code.
 
 **Flow:**
-1. Claude Code invokes `.claude/skills/session-recall/SKILL.md`.
+1. Claude Code invokes the user-level `/recall` skill (`~/.claude/skills/session-recall/SKILL.md`, symlinked from `~/wrk/common/skills/session-recall/SKILL.md`).
 2. The skill runs `session-indexer search "$QUERY" --db .claude/sessions.db --limit 10 --json`.
 3. `jq` formats results: date · role · score · snippet (400 chars).
 4. Tool-call chunks are flagged `[tool]` but not hidden.
@@ -187,7 +187,7 @@ diagnosis) would benefit from prior discussion in this project, but
 subagents start cold — no `SessionStart` hook, no shared context.
 
 **Flow:**
-1. Orchestrator runs `session-indexer search "<query>" --db .claude/sessions.db --limit 5 --json` directly — documented in `.claude/skills/session-recall/SKILL.md` under "For orchestrators / subagent prep".
+1. Orchestrator runs `session-indexer search "<query>" --db .claude/sessions.db --limit 5 --json` directly — documented in the user-level `~/.claude/skills/session-recall/SKILL.md` under "For orchestrators / subagent prep".
 2. Formats results with `jq` (date, role, snippet). Unlike `/recall`, this
    path skips the tool-call noise filter (the regex that drops raw
    Bash/Read/Write/etc. JSON blobs) — the orchestrator curates what goes


### PR DESCRIPTION
## Summary
- Update `README.md` Quick Start, `docs/use-cases.md` (UC-6 + orchestrator flow), and `docs/architecture.md` (file-layout tree + subagent pattern) to reflect that `/recall` now lives at `~/.claude/skills/session-recall/` (symlinked from `~/wrk/common/skills/session-recall/SKILL.md`) rather than a per-project `.claude/skills/session-recall/` copy.
- Follow-up to #36, which removed the per-project skill directory. The per-project hooks and `.claude/sessions.db` remain unchanged.

## Test plan
- [ ] Doc-only change — no code. Confirm the three files no longer reference a per-project `.claude/skills/session-recall/SKILL.md` path.