### PR TITLE
feat(distill): default OLLAMA_DISTILL_MODEL to glm-5.2:cloud, add --model flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Primary: embed query → exhaustive cosine over all `embeddings` rows loaded int
 
 ### Facts Layer
 
-Distilled subject-predicate-object claims, separate from raw-text `search`. `distill` (manual, never hooked into `mine`/Stop-hook budget — `context.Background()`, 120s HTTP timeout) calls Ollama `/api/generate` (`OLLAMA_DISTILL_MODEL`, default `qwen2.5:latest`) per chunk not yet in `distilled_chunks`, feeding it a bounded `CurrentFacts` context (cap 200) for supersession judgment.
+Distilled subject-predicate-object claims, separate from raw-text `search`. `distill` (manual, never hooked into `mine`/Stop-hook budget — `context.Background()`, 120s HTTP timeout) calls Ollama `/api/generate` (`OLLAMA_DISTILL_MODEL` env or `--model` flag, default `glm-5.2:cloud`) per chunk not yet in `distilled_chunks`, feeding it a bounded `CurrentFacts` context (cap 200) for supersession judgment.
 
 Confidence gate is a **deterministic Go check** (default 0.7), not an LLM-enforced instruction — the model's self-reported confidence is advisory input only. Supersession is judged automatically by the model, but the model may only cite fact ids from the context it was actually given (validated in Go); `SupersedeFact` no-ops (not an error) on an already-tombstoned fact. `facts supersede <new> <old>` is a manual audit/override backstop using the same function. See `docs/architecture.md`'s "Facts Layer" section for the full design rationale (deliberate deviations from litopys).
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ session-indexer mine    <jsonl-path> --db .claude/sessions.db
 session-indexer search  <query>      --db .claude/sessions.db [--limit N] [--json]
 session-indexer embed                --db .claude/sessions.db
 session-indexer stats                --db .claude/sessions.db
-session-indexer distill              --db .claude/sessions.db [--threshold 0.7]
+session-indexer distill              --db .claude/sessions.db [--threshold 0.7] [--model <name>]
 session-indexer facts search   <query>            --db .claude/sessions.db [--limit N] [--json] [--include-expired]
 session-indexer facts get      <id>               --db .claude/sessions.db [--json]
 session-indexer facts related  <id>               --db .claude/sessions.db [--json]
@@ -160,7 +160,7 @@ environment variables:
 |---|---|---|
 | `OLLAMA_HOST` | `http://localhost:11434` | Ollama base URL (scheme optional: `localhost:11434` works) |
 | `OLLAMA_MODEL` | `bge-m3:latest` | Embedding model name |
-| `OLLAMA_DISTILL_MODEL` | `qwen2.5:latest` | Chat/generate model used by `distill` — distinct from `OLLAMA_MODEL`, must be pulled separately (`ollama pull qwen2.5:latest` or your chosen model) |
+| `OLLAMA_DISTILL_MODEL` | `glm-5.2:cloud` | Chat/generate model used by `distill` — distinct from `OLLAMA_MODEL`, must be pulled separately (`ollama pull glm-5.2:cloud` or your chosen model). Override per-invocation with `distill --model <name>` (wins over the env var). |
 
 `mine` runs with a 50s `context.Context` deadline (headroom under the 60s
 Stop-hook budget): storing is fast and unconditional; embedding respects the

--- a/cmd/session-indexer/main.go
+++ b/cmd/session-indexer/main.go
@@ -138,6 +138,7 @@ func main() {
 	}
 
 	var threshold float64
+	var distillModel string
 	distillCmd := &cobra.Command{
 		Use:   "distill",
 		Short: "Extract structured facts from mined chunks (LLM, Ollama)",
@@ -146,10 +147,11 @@ func main() {
 			if dbPath == "" {
 				return fmt.Errorf("--db is required")
 			}
-			return runDistill(dbPath, threshold)
+			return runDistill(dbPath, threshold, distillModel)
 		},
 	}
 	distillCmd.Flags().Float64Var(&threshold, "threshold", 0.7, "minimum confidence to store a fact")
+	distillCmd.Flags().StringVar(&distillModel, "model", "", "Ollama chat/generate model (default: $OLLAMA_DISTILL_MODEL or glm-5.2:cloud)")
 
 	var factsLimit int
 	var factsJSON bool
@@ -310,13 +312,13 @@ func runEmbed(dbPath string) error {
 	return nil
 }
 
-func runDistill(dbPath string, threshold float64) error {
+func runDistill(dbPath string, threshold float64, model string) error {
 	d, err := db.Open(dbPath)
 	if err != nil {
 		return err
 	}
 	defer d.Close()
-	cli := distill.NewClient()
+	cli := distill.NewClientWithModel(model)
 	if !cli.Available() {
 		return fmt.Errorf("ollama unavailable — start it and pull the distill model (OLLAMA_DISTILL_MODEL)")
 	}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -383,9 +383,10 @@ Ollama REST call:
 ```
 POST http://localhost:11434/api/generate   (default; override with OLLAMA_HOST)
 {
-  "model": "qwen2.5:latest",   (default; override with OLLAMA_DISTILL_MODEL —
-                                 a chat/generate model, distinct from
-                                 bge-m3:latest; must be pulled separately)
+  "model": "glm-5.2:cloud",    (default; override with OLLAMA_DISTILL_MODEL env
+                                 or --model flag — a chat/generate model,
+                                 distinct from bge-m3:latest; must be pulled
+                                 separately)
   "prompt": "<template with CURRENT KNOWN FACTS + CHUNK>",
   "stream": false,
   "format": "json"

--- a/internal/distill/distill.go
+++ b/internal/distill/distill.go
@@ -45,19 +45,28 @@ type Client struct {
 //
 //	OLLAMA_HOST          — base URL (default: http://localhost:11434);
 //	                        if value has no scheme, http:// is prepended
-//	OLLAMA_DISTILL_MODEL — chat/generate model (default: qwen2.5:latest);
+//	OLLAMA_DISTILL_MODEL — chat/generate model (default: glm-5.2:cloud);
 //	                        distinct from OLLAMA_MODEL (embeddings) — must
 //	                        be pulled separately
 func NewClient() *Client {
+	return NewClientWithModel("")
+}
+
+// NewClientWithModel is NewClient but modelOverride, if non-empty, wins over
+// OLLAMA_DISTILL_MODEL and the built-in default — for a CLI --model flag.
+func NewClientWithModel(modelOverride string) *Client {
 	baseURL := os.Getenv("OLLAMA_HOST")
 	if baseURL == "" {
 		baseURL = "http://localhost:11434"
 	} else if !strings.Contains(baseURL, "://") {
 		baseURL = "http://" + baseURL
 	}
-	model := os.Getenv("OLLAMA_DISTILL_MODEL")
+	model := modelOverride
 	if model == "" {
-		model = "qwen2.5:latest"
+		model = os.Getenv("OLLAMA_DISTILL_MODEL")
+	}
+	if model == "" {
+		model = "glm-5.2:cloud"
 	}
 	return NewClientURL(baseURL, model)
 }


### PR DESCRIPTION
## Summary
- Change `distill`'s default model from `qwen2.5:latest` (never actually pulled on this machine — `Available()` always failed) to `glm-5.2:cloud` (verified working against the real prompt shape: chunk + `CurrentFacts` context, ~1-2s/call).
- Add `--model` flag to `distill`, same pattern as `--threshold` — override the model per-invocation without exporting `OLLAMA_DISTILL_MODEL`.
- `NewClient()` now delegates to `NewClientWithModel("")` — no behavior change for existing callers.

## Test plan
- [x] `go build ./... && go vet ./... && gofmt -l . && go test ./...` — all green (64 tests)
- [x] Manually verified `glm-5.2:cloud` responds correctly to the actual distill prompt shape via raw `curl` against `/api/generate`
- [x] `session-indexer distill --help` shows the new `--model` flag with correct default text