### PR TITLE
feat(distill): concurrent workers, retry-with-jitter, --limit, progress

### DIFF
--- a/cmd/session-indexer/main.go
+++ b/cmd/session-indexer/main.go
@@ -139,6 +139,9 @@ func main() {
 
 	var threshold float64
 	var distillModel string
+	var distillConcurrency int
+	var distillLimit int
+	var distillRetries int
 	distillCmd := &cobra.Command{
 		Use:   "distill",
 		Short: "Extract structured facts from mined chunks (LLM, Ollama)",
@@ -147,11 +150,14 @@ func main() {
 			if dbPath == "" {
 				return fmt.Errorf("--db is required")
 			}
-			return runDistill(dbPath, threshold, distillModel)
+			return runDistill(dbPath, threshold, distillModel, distillConcurrency, distillLimit, distillRetries)
 		},
 	}
 	distillCmd.Flags().Float64Var(&threshold, "threshold", 0.7, "minimum confidence to store a fact")
 	distillCmd.Flags().StringVar(&distillModel, "model", "", "Ollama chat/generate model (default: $OLLAMA_DISTILL_MODEL or glm-5.2:cloud)")
+	distillCmd.Flags().IntVar(&distillConcurrency, "concurrency", 1, "chunks distilled in parallel (network-bound; DB writes stay serialized; Ollama cloud 429s above ~20)")
+	distillCmd.Flags().IntVar(&distillLimit, "limit", 0, "max chunks to process this run (0 = all pending)")
+	distillCmd.Flags().IntVar(&distillRetries, "retries", 2, "extra attempts for a chunk that errors (e.g. 429), with exponential backoff, before leaving it for the next run")
 
 	var factsLimit int
 	var factsJSON bool
@@ -312,7 +318,7 @@ func runEmbed(dbPath string) error {
 	return nil
 }
 
-func runDistill(dbPath string, threshold float64, model string) error {
+func runDistill(dbPath string, threshold float64, model string, concurrency, limit, retries int) error {
 	d, err := db.Open(dbPath)
 	if err != nil {
 		return err
@@ -322,12 +328,20 @@ func runDistill(dbPath string, threshold float64, model string) error {
 	if !cli.Available() {
 		return fmt.Errorf("ollama unavailable — start it and pull the distill model (OLLAMA_DISTILL_MODEL)")
 	}
+	start := time.Now()
 	// distill is a manual, non-time-boxed command, explicitly exempt from
 	// mine's 50s/Stop-hook budget (NFR-4).
-	res, err := distill.Run(context.Background(), d, cli, distill.Config{Threshold: threshold, ContextCap: 200})
+	res, err := distill.Run(context.Background(), d, cli, distill.Config{
+		Threshold: threshold, ContextCap: 200, Concurrency: concurrency, Limit: limit, MaxRetries: retries,
+		OnProgress: func(done, total int, res distill.Result) {
+			fmt.Fprintf(os.Stderr, "\rdistill: %d/%d chunks (%d facts, %d below threshold, %d failed) [%s]",
+				done, total, res.FactsInserted, res.BelowThreshold, res.Failed, time.Since(start).Round(time.Second))
+		},
+	})
 	if err != nil {
 		return err
 	}
+	fmt.Fprintln(os.Stderr)
 	fmt.Printf("Distilled %d chunks: %d facts stored, %d below threshold, %d superseded\n",
 		res.ChunksDistilled, res.FactsInserted, res.BelowThreshold, res.Superseded)
 	if res.Failed > 0 {

--- a/internal/distill/distill.go
+++ b/internal/distill/distill.go
@@ -10,9 +10,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/valpere/session-indexer/internal"
@@ -152,7 +154,7 @@ func (c *Client) Distill(ctx context.Context, chunk string, existing []internal.
 		return nil, fmt.Errorf("ollama returned an empty response")
 	}
 	var parsed distillResponse
-	if err := json.Unmarshal([]byte(out.Response), &parsed); err != nil {
+	if err := json.Unmarshal([]byte(stripMarkdownFence(out.Response)), &parsed); err != nil {
 		return nil, fmt.Errorf("decode facts json: %w", err)
 	}
 	candidates := make([]Candidate, 0, len(parsed.Facts))
@@ -166,6 +168,23 @@ func (c *Client) Distill(ctx context.Context, chunk string, existing []internal.
 		})
 	}
 	return candidates, nil
+}
+
+// stripMarkdownFence removes a wrapping ```json ... ``` (or bare ``` ... ```)
+// fence some models emit despite "format":"json" — observed with
+// gemma4:31b-cloud; glm-5.2:cloud does not do this. A no-op on plain JSON.
+func stripMarkdownFence(s string) string {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "```") {
+		return s
+	}
+	s = strings.TrimPrefix(s, "```")
+	if nl := strings.IndexByte(s, '\n'); nl != -1 && strings.TrimSpace(s[:nl]) != "" {
+		// Fence's opening line is a language tag (e.g. "json") — drop it.
+		s = s[nl+1:]
+	}
+	s = strings.TrimSuffix(strings.TrimSpace(s), "```")
+	return strings.TrimSpace(s)
 }
 
 const promptTemplate = `You extract atomic, durable facts from a single Claude Code conversation
@@ -212,8 +231,40 @@ func buildPrompt(chunk string, existing []internal.Fact) string {
 
 // Config controls a distill Run.
 type Config struct {
-	Threshold  float64 // minimum confidence to store a fact (default 0.7)
-	ContextCap int     // max current facts to feed the distiller for supersession judgment (default 200)
+	Threshold   float64 // minimum confidence to store a fact (default 0.7)
+	ContextCap  int     // max current facts to feed the distiller for supersession judgment (default 200)
+	Concurrency int     // chunks distilled in parallel; <=1 runs strictly sequential (default)
+	Limit       int     // max chunks to process this run; <=0 means no limit (process all pending)
+
+	// MaxRetries is the number of extra Distill attempts for a chunk whose
+	// first call errors (e.g. HTTP 429 from Ollama cloud under concurrent
+	// load, or a transient timeout), before giving up and leaving the
+	// chunk for the next run. 0 (default) preserves the original
+	// single-attempt behavior. Each retry waits retryBackoff(attempt).
+	MaxRetries int
+
+	// OnProgress, if set, is called synchronously after each chunk is
+	// resolved (success or failure), from whichever goroutine finishes
+	// last — cheap and non-blocking work only (e.g. a log line).
+	OnProgress func(done, total int, res Result)
+}
+
+// retryBackoff is the delay before retry attempt n (0-indexed, so n=0 is the
+// wait before the first retry): ~500ms, 1s, 2s, 4s, capped at 8s, each
+// jittered +/-25%. Ollama cloud's 429 responses carry no Retry-After header
+// to key off instead. The jitter matters under concurrency: a fixed
+// schedule means every worker that got 429'd in the same instant retries in
+// the same instant too, reproducing the same burst that caused the 429 in
+// the first place (observed empirically — retries alone, un-jittered, still
+// left ~20% of a concurrency=20 run failed).
+func retryBackoff(attempt int) time.Duration {
+	d := 500 * time.Millisecond * (1 << attempt)
+	const maxDelay = 8 * time.Second
+	if d > maxDelay {
+		d = maxDelay
+	}
+	jitter := time.Duration(rand.Int64N(int64(d)/2)) - d/4 // +/-25%
+	return d + jitter
 }
 
 // Result summarizes a distill run.
@@ -225,6 +276,16 @@ type Result struct {
 	Failed          int
 }
 
+// fetchOutcome is one chunk's Distill call result, produced by a worker and
+// consumed by Run's single DB-writing loop.
+type fetchOutcome struct {
+	chunk           db.PendingFactChunk
+	candidates      []Candidate
+	err             error
+	promptContext   []internal.Fact
+	contextExceeded bool
+}
+
 // Run distills every chunk pending in d via cli, applying cfg's confidence
 // gate deterministically in Go (the model's self-reported confidence is
 // advisory input to this hard check, not the enforcement mechanism).
@@ -233,42 +294,120 @@ type Result struct {
 // distill is a manual, non-time-boxed command, explicitly exempt from
 // mine's 50s/Stop-hook budget. The passed ctx still governs overall
 // cancellation (e.g. Ctrl-C) between chunks.
+//
+// cfg.Concurrency workers fetch existing-facts context and call cli.Distill
+// (the network-bound step) in parallel; every DB write (InsertFact,
+// SupersedeFact, MarkChunkDistilled) happens sequentially in this function's
+// own goroutine as outcomes arrive, so SQLite never sees concurrent writers.
+// A side effect: "current facts" context fed to concurrently-in-flight
+// chunks may be a few facts stale relative to strictly sequential Run — the
+// same tradeoff any batched/parallel supersession pipeline makes.
+//
+// A chunk whose Distill call errors is retried up to cfg.MaxRetries times
+// with retryBackoff between attempts, still within this same call — Ollama
+// cloud returns a plain 429 (no Retry-After) once concurrent in-flight
+// requests exceed roughly 20, and without this a high-concurrency run loses
+// a large fraction of its chunks to rate limiting instead of just slowing
+// down. A chunk still failing after the retry budget is left unmarked, same
+// as before — picked up on the next Run.
 func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, error) {
 	var res Result
 	pending, err := db.ChunksWithoutFacts(d)
 	if err != nil {
 		return res, err
 	}
-	for _, p := range pending {
-		if ctx.Err() != nil {
-			return res, ctx.Err()
-		}
-		existing, err := db.CurrentFacts(d, cfg.ContextCap+1)
-		if err != nil {
-			return res, err
-		}
-		// ContextCap exceeded: omit context and skip auto-supersession for
-		// this call — an oversized context would blow the prompt budget
-		// and the model has nothing reliable to judge supersession against.
-		contextExceeded := len(existing) > cfg.ContextCap
-		promptContext := existing
-		if contextExceeded {
-			promptContext = nil
-		}
-		allowedIDs := make(map[int64]bool, len(promptContext))
-		for _, f := range promptContext {
-			allowedIDs[f.ID] = true
-		}
+	if cfg.Limit > 0 && len(pending) > cfg.Limit {
+		pending = pending[:cfg.Limit]
+	}
+	total := len(pending)
 
-		// context.Background(), not ctx: distill is exempt from the
-		// caller's deadline (see doc comment above) — ctx only governs
-		// cancellation between chunks, checked via ctx.Err() above.
-		candidates, err := cli.Distill(context.Background(), p.Content, promptContext)
-		if err != nil {
-			res.Failed++
-			continue // chunk not marked — retried on the next run
+	concurrency := cfg.Concurrency
+	if concurrency < 1 {
+		concurrency = 1
+	}
+
+	jobs := make(chan db.PendingFactChunk)
+	outcomes := make(chan fetchOutcome)
+
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			defer wg.Done()
+			for p := range jobs {
+				if ctx.Err() != nil {
+					return
+				}
+				existing, err := db.CurrentFacts(d, cfg.ContextCap+1)
+				if err != nil {
+					outcomes <- fetchOutcome{chunk: p, err: err}
+					continue
+				}
+				// ContextCap exceeded: omit context and skip
+				// auto-supersession for this call — an oversized context
+				// would blow the prompt budget and the model has nothing
+				// reliable to judge supersession against.
+				contextExceeded := len(existing) > cfg.ContextCap
+				promptContext := existing
+				if contextExceeded {
+					promptContext = nil
+				}
+				// context.Background(), not ctx: distill is exempt from the
+				// caller's deadline (see doc comment above) — ctx only
+				// governs cancellation between chunks.
+				var candidates []Candidate
+				var derr error
+				for attempt := 0; ; attempt++ {
+					candidates, derr = cli.Distill(context.Background(), p.Content, promptContext)
+					if derr == nil || attempt >= cfg.MaxRetries {
+						break
+					}
+					select {
+					case <-time.After(retryBackoff(attempt)):
+					case <-ctx.Done():
+					}
+					if ctx.Err() != nil {
+						break
+					}
+				}
+				outcomes <- fetchOutcome{
+					chunk: p, candidates: candidates, err: derr,
+					promptContext: promptContext, contextExceeded: contextExceeded,
+				}
+			}
+		}()
+	}
+	go func() {
+		defer close(jobs)
+		for _, p := range pending {
+			select {
+			case jobs <- p:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	go func() {
+		wg.Wait()
+		close(outcomes)
+	}()
+
+	done := 0
+	for oc := range outcomes {
+		done++
+		if oc.err != nil {
+			res.Failed++ // chunk not marked — retried on the next run
+			if cfg.OnProgress != nil {
+				cfg.OnProgress(done, total, res)
+			}
+			continue
 		}
 		res.ChunksDistilled++
+
+		allowedIDs := make(map[int64]bool, len(oc.promptContext))
+		for _, f := range oc.promptContext {
+			allowedIDs[f.ID] = true
+		}
 
 		now := time.Now().UTC().Format(time.RFC3339)
 		// storeFailed tracks whether any candidate for this chunk hit a DB
@@ -277,7 +416,7 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 		// retried on the next run, same as a Distill call failure above —
 		// a transient DB error must not permanently drop a candidate fact.
 		var storeFailed bool
-		for _, c := range candidates {
+		for _, c := range oc.candidates {
 			if c.Confidence < cfg.Threshold {
 				res.BelowThreshold++
 				continue
@@ -287,8 +426,8 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 				Predicate:     c.Predicate,
 				Object:        c.Object,
 				Confidence:    c.Confidence,
-				SourceChunkID: p.ID,
-				SessionDate:   p.SessionDate,
+				SourceChunkID: oc.chunk.ID,
+				SessionDate:   oc.chunk.SessionDate,
 				CreatedAt:     now,
 			})
 			if err != nil {
@@ -297,7 +436,7 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 				continue
 			}
 			res.FactsInserted++
-			if contextExceeded {
+			if oc.contextExceeded {
 				continue
 			}
 			for _, oldID := range c.SupersedesIDs {
@@ -317,12 +456,20 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 				}
 			}
 		}
-		if storeFailed {
-			continue // chunk not marked — retried on the next run
+		if !storeFailed {
+			// A MarkChunkDistilled error here is a DB-level failure, not a
+			// content problem — the chunk is retried next run just like the
+			// other failure paths above, rather than aborting the fan-out.
+			if err := db.MarkChunkDistilled(d, oc.chunk.ID, now); err != nil {
+				res.Failed++
+			}
 		}
-		if err := db.MarkChunkDistilled(d, p.ID, now); err != nil {
-			return res, err
+		if cfg.OnProgress != nil {
+			cfg.OnProgress(done, total, res)
 		}
+	}
+	if ctx.Err() != nil {
+		return res, ctx.Err()
 	}
 	return res, nil
 }

--- a/internal/distill/distill.go
+++ b/internal/distill/distill.go
@@ -244,8 +244,9 @@ type Config struct {
 	MaxRetries int
 
 	// OnProgress, if set, is called synchronously after each chunk is
-	// resolved (success or failure), from whichever goroutine finishes
-	// last — cheap and non-blocking work only (e.g. a log line).
+	// resolved (success or failure), always from Run's own single
+	// outcome-processing goroutine (never from a worker) — cheap and
+	// non-blocking work only (e.g. a log line).
 	OnProgress func(done, total int, res Result)
 }
 
@@ -258,8 +259,15 @@ type Config struct {
 // the first place (observed empirically — retries alone, un-jittered, still
 // left ~20% of a concurrency=20 run failed).
 func retryBackoff(attempt int) time.Duration {
-	d := 500 * time.Millisecond * (1 << attempt)
 	const maxDelay = 8 * time.Second
+	// 500ms*2^4 already reaches maxDelay, so clamp attempt before the
+	// shift — 1<<attempt otherwise overflows int64 around attempt~=35
+	// (reachable via --retries with a large value), producing a negative
+	// d that made rand.Int64N(int64(d)/2) panic.
+	if attempt > 4 {
+		attempt = 4
+	}
+	d := 500 * time.Millisecond * (1 << attempt)
 	if d > maxDelay {
 		d = maxDelay
 	}

--- a/internal/distill/distill_test.go
+++ b/internal/distill/distill_test.go
@@ -3,10 +3,14 @@ package distill
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/valpere/session-indexer/internal"
@@ -50,6 +54,48 @@ func TestDistillParsesFacts(t *testing.T) {
 	}
 	if candidates[0].Confidence != 0.95 {
 		t.Fatalf("confidence = %v, want 0.95", candidates[0].Confidence)
+	}
+}
+
+// TestDistillParsesFencedFacts verifies a response wrapped in a markdown
+// ```json fence still parses — observed from gemma4:31b-cloud, which
+// ignores the "format":"json" request parameter. glm-5.2:cloud does not do
+// this, so this guards against a model swap silently breaking every chunk.
+func TestDistillParsesFencedFacts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"response":"` +
+			"```json\\n{\\\"facts\\\":[{\\\"subject\\\":\\\"s\\\",\\\"predicate\\\":\\\"p\\\",\\\"object\\\":\\\"o\\\",\\\"confidence\\\":0.9,\\\"supersedes_ids\\\":[]}]}\\n```" +
+			`"}`))
+	}))
+	defer srv.Close()
+	c := NewClientURL(srv.URL, "gemma4:31b-cloud")
+	candidates, err := c.Distill(context.Background(), "chunk text", nil)
+	if err != nil {
+		t.Fatalf("Distill: %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].Subject != "s" {
+		t.Fatalf("candidates = %+v", candidates)
+	}
+}
+
+func TestStripMarkdownFence(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain JSON untouched", `{"facts":[]}`, `{"facts":[]}`},
+		{"fenced with json tag", "```json\n{\"facts\":[]}\n```", `{"facts":[]}`},
+		{"fenced without tag", "```\n{\"facts\":[]}\n```", `{"facts":[]}`},
+		{"surrounding whitespace", "  \n```json\n{\"facts\":[]}\n```\n  ", `{"facts":[]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripMarkdownFence(tc.in)
+			if got != tc.want {
+				t.Fatalf("stripMarkdownFence(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -108,6 +154,39 @@ func (s *stubDistiller) Distill(_ context.Context, chunk string, existing []inte
 	f := s.calls[s.n]
 	s.n++
 	return f(chunk, existing)
+}
+
+// fixedDistiller is a concurrency-safe Distiller test double: every call
+// gets the same canned response regardless of input or call order. Used by
+// concurrency tests where stubDistiller's ordered call queue isn't
+// meaningful (workers race to call Distill in unpredictable order).
+type fixedDistiller struct {
+	avail bool
+	fn    func(chunk string, existing []internal.Fact) ([]Candidate, error)
+}
+
+func (f *fixedDistiller) Available() bool { return f.avail }
+func (f *fixedDistiller) Distill(_ context.Context, chunk string, existing []internal.Fact) ([]Candidate, error) {
+	return f.fn(chunk, existing)
+}
+
+// flakyDistiller fails its first failCount calls (thread-safe via atomic
+// counter, so it also works under Config.Concurrency>1), then delegates to
+// succeed — used to test Run's retry-on-failure behavior.
+type flakyDistiller struct {
+	avail     bool
+	failCount int64
+	calls     int64
+	succeed   func(chunk string, existing []internal.Fact) ([]Candidate, error)
+}
+
+func (f *flakyDistiller) Available() bool { return f.avail }
+func (f *flakyDistiller) Distill(_ context.Context, chunk string, existing []internal.Fact) ([]Candidate, error) {
+	n := atomic.AddInt64(&f.calls, 1)
+	if n <= f.failCount {
+		return nil, errors.New("simulated transient failure")
+	}
+	return f.succeed(chunk, existing)
 }
 
 // Package-level counter, safe only because no test in this suite (or this
@@ -238,6 +317,55 @@ func TestRunLeavesChunkOnError(t *testing.T) {
 	}
 }
 
+// TestRunRetriesOnFailureThenSucceeds models an Ollama cloud 429: the first
+// two Distill calls for a chunk fail, the third (within MaxRetries budget)
+// succeeds — the chunk must land as distilled within this same Run, not be
+// left for the next one.
+func TestRunRetriesOnFailureThenSucceeds(t *testing.T) {
+	d := openTestDB(t)
+	seedChunk(t, d, "chunk that succeeds on the third attempt", "2026-07-01")
+	cli := &flakyDistiller{avail: true, failCount: 2, succeed: func(string, []internal.Fact) ([]Candidate, error) {
+		return []Candidate{{Subject: "s", Predicate: "p", Object: "o", Confidence: 0.9}}, nil
+	}}
+	res, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200, MaxRetries: 2})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Failed != 0 || res.ChunksDistilled != 1 || res.FactsInserted != 1 {
+		t.Fatalf("res = %+v, want Failed=0 ChunksDistilled=1 FactsInserted=1", res)
+	}
+	if got := atomic.LoadInt64(&cli.calls); got != 3 {
+		t.Fatalf("Distill called %d times, want 3 (1 initial + 2 retries)", got)
+	}
+	pending, err := db.ChunksWithoutFacts(d)
+	if err != nil || len(pending) != 0 {
+		t.Fatalf("pending after eventual success = %+v err=%v, want none", pending, err)
+	}
+}
+
+// TestRunRetryBudgetExhausted verifies a chunk that fails every attempt,
+// including all retries, is still left pending for the next run — retry
+// must not turn a permanent failure into a silently dropped chunk.
+func TestRunRetryBudgetExhausted(t *testing.T) {
+	d := openTestDB(t)
+	seedChunk(t, d, "chunk that always fails", "2026-07-01")
+	cli := &flakyDistiller{avail: true, failCount: 1000}
+	res, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200, MaxRetries: 1})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Failed != 1 {
+		t.Fatalf("res.Failed = %d, want 1", res.Failed)
+	}
+	if got := atomic.LoadInt64(&cli.calls); got != 2 {
+		t.Fatalf("Distill called %d times, want 2 (1 initial + 1 retry)", got)
+	}
+	pending, err := db.ChunksWithoutFacts(d)
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending after exhausted retries = %+v err=%v, want 1 (retried next run)", pending, err)
+	}
+}
+
 // TestRunLeavesChunkOnInsertFactError verifies that a DB-level failure
 // storing a candidate fact (not a Distill call failure) also leaves the
 // chunk unmarked, consistent with the "chunk not marked — retried on the
@@ -330,5 +458,99 @@ func TestRunRejectsSupersedeIDOutsideContext(t *testing.T) {
 	}
 	if res.Superseded != 0 {
 		t.Fatalf("res.Superseded = %d, want 0 (id 999 was never in the given context)", res.Superseded)
+	}
+}
+
+func TestRunRespectsLimit(t *testing.T) {
+	d := openTestDB(t)
+	seedChunk(t, d, "chunk one", "2026-07-01")
+	seedChunk(t, d, "chunk two", "2026-07-02")
+	seedChunk(t, d, "chunk three", "2026-07-03")
+	cli := &fixedDistiller{avail: true, fn: func(string, []internal.Fact) ([]Candidate, error) {
+		return nil, nil
+	}}
+	res, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200, Limit: 2})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.ChunksDistilled != 2 {
+		t.Fatalf("res.ChunksDistilled = %d, want 2", res.ChunksDistilled)
+	}
+	pending, err := db.ChunksWithoutFacts(d)
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending after Limit=2 run = %+v err=%v, want 1 left over", pending, err)
+	}
+}
+
+// TestRunConcurrencyProcessesAllChunks seeds enough chunks that a
+// Concurrency>1 run has multiple workers genuinely in flight, and checks
+// every chunk is still accounted for exactly once. Run with -race: workers
+// share d and cli, so a locking bug here shows up as a race, not just a
+// wrong count.
+func TestRunConcurrencyProcessesAllChunks(t *testing.T) {
+	d := openTestDB(t)
+	const n = 20
+	for i := 0; i < n; i++ {
+		seedChunk(t, d, "concurrent chunk", "2026-07-01")
+	}
+	var calls int64
+	cli := &fixedDistiller{avail: true, fn: func(string, []internal.Fact) ([]Candidate, error) {
+		atomic.AddInt64(&calls, 1)
+		return []Candidate{{Subject: "s", Predicate: "p", Object: "o", Confidence: 0.9}}, nil
+	}}
+	res, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200, Concurrency: 5})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.ChunksDistilled != n || res.FactsInserted != n {
+		t.Fatalf("res = %+v, want ChunksDistilled=%d FactsInserted=%d", res, n, n)
+	}
+	if atomic.LoadInt64(&calls) != n {
+		t.Fatalf("Distill called %d times, want %d", calls, n)
+	}
+	pending, err := db.ChunksWithoutFacts(d)
+	if err != nil || len(pending) != 0 {
+		t.Fatalf("pending after full concurrent run = %+v err=%v, want none", pending, err)
+	}
+}
+
+func TestRunProgressCallback(t *testing.T) {
+	d := openTestDB(t)
+	const n = 5
+	for i := 0; i < n; i++ {
+		seedChunk(t, d, "chunk", "2026-07-01")
+	}
+	cli := &fixedDistiller{avail: true, fn: func(string, []internal.Fact) ([]Candidate, error) {
+		return nil, nil
+	}}
+	var mu sync.Mutex
+	var doneSeen []int
+	var lastTotal int
+	res, err := Run(context.Background(), d, cli, Config{
+		Threshold: 0.7, ContextCap: 200, Concurrency: 3,
+		OnProgress: func(done, total int, _ Result) {
+			mu.Lock()
+			defer mu.Unlock()
+			doneSeen = append(doneSeen, done)
+			lastTotal = total
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.ChunksDistilled != n {
+		t.Fatalf("res.ChunksDistilled = %d, want %d", res.ChunksDistilled, n)
+	}
+	if len(doneSeen) != n {
+		t.Fatalf("OnProgress called %d times, want %d", len(doneSeen), n)
+	}
+	if lastTotal != n {
+		t.Fatalf("OnProgress total = %d, want %d", lastTotal, n)
+	}
+	sort.Ints(doneSeen)
+	for i, v := range doneSeen {
+		if v != i+1 {
+			t.Fatalf("OnProgress done values = %v, want 1..%d each exactly once", doneSeen, n)
+		}
 	}
 }

--- a/internal/distill/distill_test.go
+++ b/internal/distill/distill_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/valpere/session-indexer/internal"
 	"github.com/valpere/session-indexer/internal/db"
@@ -552,5 +553,56 @@ func TestRunProgressCallback(t *testing.T) {
 		if v != i+1 {
 			t.Fatalf("OnProgress done values = %v, want 1..%d each exactly once", doneSeen, n)
 		}
+	}
+}
+
+// TestRunCtxCancellationDuringConcurrentRun cancels ctx while several
+// workers are genuinely in flight (Concurrency>1) and asserts Run still
+// returns promptly with ctx.Err() — a worker that sees ctx cancelled at
+// the top of its jobs loop returns without sending an outcome for that
+// chunk, but wg.Wait()+close(outcomes) still fires regardless, so this
+// must never hang or leak, only leave the un-dispatched chunks pending
+// for the next run. Run with -race: a bug here would show as a hang
+// (caught by the timeout below) or a data race on res/doneSeen.
+func TestRunCtxCancellationDuringConcurrentRun(t *testing.T) {
+	d := openTestDB(t)
+	const n = 50
+	for i := 0; i < n; i++ {
+		seedChunk(t, d, "chunk", "2026-07-01")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cli := &fixedDistiller{avail: true, fn: func(string, []internal.Fact) ([]Candidate, error) {
+		time.Sleep(20 * time.Millisecond)
+		return []Candidate{{Subject: "s", Predicate: "p", Object: "o", Confidence: 0.9}}, nil
+	}}
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan struct{})
+	var res Result
+	var err error
+	go func() {
+		res, err = Run(ctx, d, cli, Config{Threshold: 0.7, ContextCap: 200, Concurrency: 5})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return within 5s after ctx cancellation — hang or goroutine leak")
+	}
+	if err == nil {
+		t.Fatalf("Run returned nil error after ctx cancellation, res=%+v", res)
+	}
+
+	pending, perr := db.ChunksWithoutFacts(d)
+	if perr != nil {
+		t.Fatalf("ChunksWithoutFacts: %v", perr)
+	}
+	if res.ChunksDistilled+len(pending) != n {
+		t.Fatalf("res.ChunksDistilled=%d + pending=%d = %d, want %d (every chunk accounted for exactly once)",
+			res.ChunksDistilled, len(pending), res.ChunksDistilled+len(pending), n)
 	}
 }


### PR DESCRIPTION
## Summary
- `distill.Run` gains `Concurrency` (worker pool over the network-bound Ollama call; DB writes stay serialized), `Limit` (cap chunks per invocation), `MaxRetries` (jittered exponential backoff on failure), and `OnProgress`.
- Fixes `Distill()` silently failing on every chunk against `gemma4:31b-cloud`, which wraps its response in a ` ```json ` fence despite `format:"json"` — `glm-5.2:cloud` doesn't do this, so it went unnoticed until testing a model swap.
- CLI: `distill` gains `--concurrency`, `--limit`, `--retries` (default 2).

## Why
Serial distill was impractical at scale: ~1 chunk/15-20s meant the ~20k-chunk backlog in the largest project DBs (common, lance-agent) would take days to catch up. Empirically probed Ollama cloud's rate limit (plain 429, no Retry-After, kicks in above ~20 concurrent in-flight requests) and tuned retry/backoff against it — concurrency 15 is failure-free, concurrency 20+ needs the retry/jitter to recover most of what gets rate-limited.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./... -race -count=1` — 75/75 pass
- [x] New tests: `Limit`, concurrency correctness under `-race`, progress callback, markdown-fence parsing, retry-then-succeed, retry-budget-exhausted
- [x] Manually verified against a real Ollama cloud endpoint (ragivka project DB): concurrency 5/15 → 0 failures; concurrency 20 → some 429s, recovered by retry+jitter, residual failures self-heal on next run (chunk stays unmarked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)