### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 
 BINARY   := bin/session-indexer
 TEST_PKG ?= ./...
-VERSION  := $(shell git describe --tags --exact-match 2>/dev/null || echo "0.1.0")
+VERSION  := $(shell git describe --tags --exact-match 2>/dev/null || echo "0.2.0")
 LDFLAGS  := -ldflags "-X main.version=$(VERSION)"
 
 build: ## build to bin/session-indexer

--- a/cmd/session-indexer/main.go
+++ b/cmd/session-indexer/main.go
@@ -21,7 +21,7 @@ import (
 
 // version is the current release; overridden at build time via
 // -ldflags "-X main.version=x.y.z" (see Makefile).
-var version = "0.1.0"
+var version = "0.2.0"
 
 func main() {
 	var dbPath string


### PR DESCRIPTION
## Summary
- Bump `main.version` and the Makefile's fallback `VERSION` from 0.1.0 to 0.2.0.

## Test plan
- [x] `make build` succeeds
- [x] `./bin/session-indexer --version` prints `session-indexer version 0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)