### PR TITLE
feat(distill): circuit breaker + graceful stop, resumable by design

### DIFF
--- a/cmd/session-indexer/main.go
+++ b/cmd/session-indexer/main.go
@@ -376,11 +376,16 @@ func runDistill(dbPath string, threshold float64, model string, concurrency, lim
 	fmt.Fprintln(os.Stderr)
 	// Print what happened even on early stop — done, ErrCircuitBreaker, and
 	// ctx.Err() (Ctrl-C) all leave real, durable progress worth reporting,
-	// not just a bare error.
-	fmt.Printf("Distilled %d chunks: %d facts stored, %d below threshold, %d superseded\n",
-		res.ChunksDistilled, res.FactsInserted, res.BelowThreshold, res.Superseded)
-	if res.Failed > 0 {
-		fmt.Fprintf(os.Stderr, "warn: %d chunks failed to distill\n", res.Failed)
+	// not just a bare error. A generic error (e.g. ChunksWithoutFacts
+	// failing before any chunk was even dispatched) gets none of this —
+	// printing "Distilled 0 chunks" right before "error: ..." would read
+	// as a spurious success line for a run that never started.
+	if err == nil || errors.Is(err, distill.ErrCircuitBreaker) || errors.Is(err, context.Canceled) {
+		fmt.Printf("Distilled %d chunks: %d facts stored, %d below threshold, %d superseded\n",
+			res.ChunksDistilled, res.FactsInserted, res.BelowThreshold, res.Superseded)
+		if res.Failed > 0 {
+			fmt.Fprintf(os.Stderr, "warn: %d chunks failed to distill\n", res.Failed)
+		}
 	}
 	switch {
 	case errors.Is(err, distill.ErrCircuitBreaker):

--- a/cmd/session-indexer/main.go
+++ b/cmd/session-indexer/main.go
@@ -3,10 +3,13 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -142,15 +145,21 @@ func main() {
 	var distillConcurrency int
 	var distillLimit int
 	var distillRetries int
+	var distillCircuitBreaker int
 	distillCmd := &cobra.Command{
 		Use:   "distill",
 		Short: "Extract structured facts from mined chunks (LLM, Ollama)",
-		Args:  cobra.NoArgs,
+		Long: "Extract structured facts from mined chunks (LLM, Ollama).\n\n" +
+			"Safe to interrupt (Ctrl-C / SIGTERM) or stop early: chunks are marked\n" +
+			"distilled one at a time as they complete, so re-running the same\n" +
+			"command later picks up exactly where this run left off — nothing to\n" +
+			"resume manually.",
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if dbPath == "" {
 				return fmt.Errorf("--db is required")
 			}
-			return runDistill(dbPath, threshold, distillModel, distillConcurrency, distillLimit, distillRetries)
+			return runDistill(dbPath, threshold, distillModel, distillConcurrency, distillLimit, distillRetries, distillCircuitBreaker)
 		},
 	}
 	distillCmd.Flags().Float64Var(&threshold, "threshold", 0.7, "minimum confidence to store a fact")
@@ -158,6 +167,7 @@ func main() {
 	distillCmd.Flags().IntVar(&distillConcurrency, "concurrency", 1, "chunks distilled in parallel (network-bound; DB writes stay serialized; Ollama cloud 429s above ~20)")
 	distillCmd.Flags().IntVar(&distillLimit, "limit", 0, "max chunks to process this run (0 = all pending)")
 	distillCmd.Flags().IntVar(&distillRetries, "retries", 2, "extra attempts for a chunk that errors (e.g. 429), with exponential backoff, before leaving it for the next run")
+	distillCmd.Flags().IntVar(&distillCircuitBreaker, "circuit-breaker", 5, "stop the run after this many consecutive chunks fail all their retries (0 disables; signals a persistent outage, not a blip — e.g. Ollama quota exhausted)")
 
 	var factsLimit int
 	var factsJSON bool
@@ -279,8 +289,25 @@ func main() {
 
 	root.AddCommand(mineCmd, searchCmd, embedCmd, statsCmd, distillCmd, factsCmd)
 	if err := root.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, "error:", err)
-		os.Exit(1)
+		switch {
+		case errors.Is(err, distill.ErrCircuitBreaker):
+			// runDistill already explained the stop and how to resume —
+			// don't repeat it with a generic "error:" prefix. Exit code 2
+			// (distinct from 1) lets a wrapper script like
+			// bin/distill-backfill.sh tell "this project hit a persistent
+			// Ollama problem" apart from an ordinary failure and stop
+			// trying the rest of the backlog instead of hammering a dead
+			// endpoint project after project.
+			os.Exit(2)
+		case errors.Is(err, context.Canceled):
+			// Likewise already explained by runDistill; SIGINT/SIGTERM
+			// already reached the whole process group, so there's nothing
+			// left for a wrapper script to specially detect here.
+			os.Exit(130)
+		default:
+			fmt.Fprintln(os.Stderr, "error:", err)
+			os.Exit(1)
+		}
 	}
 }
 
@@ -318,7 +345,7 @@ func runEmbed(dbPath string) error {
 	return nil
 }
 
-func runDistill(dbPath string, threshold float64, model string, concurrency, limit, retries int) error {
+func runDistill(dbPath string, threshold float64, model string, concurrency, limit, retries, circuitBreaker int) error {
 	d, err := db.Open(dbPath)
 	if err != nil {
 		return err
@@ -329,23 +356,42 @@ func runDistill(dbPath string, threshold float64, model string, concurrency, lim
 		return fmt.Errorf("ollama unavailable — start it and pull the distill model (OLLAMA_DISTILL_MODEL)")
 	}
 	start := time.Now()
-	// distill is a manual, non-time-boxed command, explicitly exempt from
-	// mine's 50s/Stop-hook budget (NFR-4).
-	res, err := distill.Run(context.Background(), d, cli, distill.Config{
-		Threshold: threshold, ContextCap: 200, Concurrency: concurrency, Limit: limit, MaxRetries: retries,
+	// SIGINT/SIGTERM cancel the context passed to distill.Run instead of
+	// killing the process outright: Run stops dispatching new chunks but
+	// lets whatever's already in flight finish and get written, so a
+	// Ctrl-C mid-run never loses a chunk that had already succeeded — it's
+	// just picked up again (ChunksWithoutFacts) on the next invocation.
+	ctx, stopSignal := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stopSignal()
+	// distill is otherwise a manual, non-time-boxed command, explicitly
+	// exempt from mine's 50s/Stop-hook budget (NFR-4).
+	res, err := distill.Run(ctx, d, cli, distill.Config{
+		Threshold: threshold, ContextCap: 200, Concurrency: concurrency, Limit: limit,
+		MaxRetries: retries, CircuitBreaker: circuitBreaker,
 		OnProgress: func(done, total int, res distill.Result) {
 			fmt.Fprintf(os.Stderr, "\rdistill: %d/%d chunks (%d facts, %d below threshold, %d failed) [%s]",
 				done, total, res.FactsInserted, res.BelowThreshold, res.Failed, time.Since(start).Round(time.Second))
 		},
 	})
-	if err != nil {
-		return err
-	}
 	fmt.Fprintln(os.Stderr)
+	// Print what happened even on early stop — done, ErrCircuitBreaker, and
+	// ctx.Err() (Ctrl-C) all leave real, durable progress worth reporting,
+	// not just a bare error.
 	fmt.Printf("Distilled %d chunks: %d facts stored, %d below threshold, %d superseded\n",
 		res.ChunksDistilled, res.FactsInserted, res.BelowThreshold, res.Superseded)
 	if res.Failed > 0 {
 		fmt.Fprintf(os.Stderr, "warn: %d chunks failed to distill\n", res.Failed)
+	}
+	switch {
+	case errors.Is(err, distill.ErrCircuitBreaker):
+		fmt.Fprintf(os.Stderr, "stopped: %v — likely a persistent Ollama problem (quota exhausted, endpoint down), not a blip\n", err)
+		fmt.Fprintln(os.Stderr, "re-run the same command later to continue from here")
+		return err
+	case errors.Is(err, context.Canceled):
+		fmt.Fprintln(os.Stderr, "stopped: interrupted — re-run the same command later to continue from here")
+		return err
+	case err != nil:
+		return err
 	}
 	return nil
 }

--- a/internal/distill/distill.go
+++ b/internal/distill/distill.go
@@ -344,6 +344,14 @@ type fetchOutcome struct {
 // way and returns ctx.Err(). Either way, every chunk marked distilled before
 // the stop is durable — nothing to "resume" beyond calling Run again later;
 // ChunksWithoutFacts will simply pick up where this call left off.
+//
+// "Consecutive" is counted in outcome-arrival order, not dispatch order —
+// under Concurrency>1 a still-in-flight chunk dispatched before a failing
+// streak can report success afterwards and reset the count. In a genuine
+// persistent outage this only delays the trip by at most Concurrency-1
+// extra failures, never masks it (verified: Concurrency=8, CircuitBreaker=3
+// against an always-failing Distiller trips within 11 calls, not the full
+// backlog).
 func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, error) {
 	var res Result
 	pending, err := db.ChunksWithoutFacts(d)
@@ -436,6 +444,9 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 	}()
 
 	done := 0
+	// consecutiveFailures and breakerTripped, like res itself, are only
+	// ever touched here in Run's own single outcome-processing goroutine —
+	// never by a worker — so no locking is needed.
 	var consecutiveFailures int
 	var breakerTripped bool
 	for oc := range outcomes {

--- a/internal/distill/distill.go
+++ b/internal/distill/distill.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -20,6 +21,15 @@ import (
 	"github.com/valpere/session-indexer/internal"
 	"github.com/valpere/session-indexer/internal/db"
 )
+
+// ErrCircuitBreaker is returned by Run (wrapped, with the streak length) when
+// cfg.CircuitBreaker consecutive chunks each exhaust their retry budget and
+// still fail — a persistent condition (Ollama cloud quota/rate exhausted for
+// the day, endpoint unreachable) rather than the transient blips MaxRetries
+// already absorbs. Callers should treat it as "stop and try again later",
+// not a bug: chunks already marked distilled before the trip are durable,
+// so the next Run naturally resumes from where this one gave up.
+var ErrCircuitBreaker = errors.New("distill: circuit breaker tripped")
 
 // Candidate is one fact proposed by the distiller for a single chunk.
 type Candidate struct {
@@ -243,6 +253,13 @@ type Config struct {
 	// single-attempt behavior. Each retry waits retryBackoff(attempt).
 	MaxRetries int
 
+	// CircuitBreaker stops Run early — no further chunks dispatched,
+	// already-in-flight ones allowed to finish — after this many
+	// consecutive chunks each exhaust MaxRetries and still fail. 0
+	// (default) disables it: Run always drains every pending chunk
+	// regardless of failure streaks, matching the original behavior.
+	CircuitBreaker int
+
 	// OnProgress, if set, is called synchronously after each chunk is
 	// resolved (success or failure), always from Run's own single
 	// outcome-processing goroutine (never from a worker) — cheap and
@@ -318,6 +335,15 @@ type fetchOutcome struct {
 // a large fraction of its chunks to rate limiting instead of just slowing
 // down. A chunk still failing after the retry budget is left unmarked, same
 // as before — picked up on the next Run.
+//
+// If cfg.CircuitBreaker consecutive chunks each exhaust their retry budget,
+// Run stops dispatching further chunks (already-in-flight ones are allowed
+// to finish, same "graceful, not abrupt" treatment as ctx cancellation) and
+// returns ErrCircuitBreaker. External cancellation of ctx itself (e.g. the
+// caller wiring SIGINT/SIGTERM via signal.NotifyContext) is handled the same
+// way and returns ctx.Err(). Either way, every chunk marked distilled before
+// the stop is durable — nothing to "resume" beyond calling Run again later;
+// ChunksWithoutFacts will simply pick up where this call left off.
 func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, error) {
 	var res Result
 	pending, err := db.ChunksWithoutFacts(d)
@@ -334,6 +360,14 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 		concurrency = 1
 	}
 
+	// runCtx is what dispatch/workers actually watch for "stop now": it's
+	// cancelled either by the caller (ctx) or by us, internally, when the
+	// circuit breaker trips. Distinguishing the two causes at the end is
+	// what lets Run report ErrCircuitBreaker instead of a bare ctx.Err()
+	// for a self-inflicted stop.
+	runCtx, cancelRun := context.WithCancel(ctx)
+	defer cancelRun()
+
 	jobs := make(chan db.PendingFactChunk)
 	outcomes := make(chan fetchOutcome)
 
@@ -343,7 +377,7 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 		go func() {
 			defer wg.Done()
 			for p := range jobs {
-				if ctx.Err() != nil {
+				if runCtx.Err() != nil {
 					return
 				}
 				existing, err := db.CurrentFacts(d, cfg.ContextCap+1)
@@ -360,9 +394,10 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 				if contextExceeded {
 					promptContext = nil
 				}
-				// context.Background(), not ctx: distill is exempt from the
-				// caller's deadline (see doc comment above) — ctx only
-				// governs cancellation between chunks.
+				// context.Background(), not runCtx: distill is exempt from
+				// the caller's deadline (see doc comment above) — runCtx
+				// only governs cancellation between chunks/retries, an
+				// in-flight Ollama call is always let finish.
 				var candidates []Candidate
 				var derr error
 				for attempt := 0; ; attempt++ {
@@ -372,9 +407,9 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 					}
 					select {
 					case <-time.After(retryBackoff(attempt)):
-					case <-ctx.Done():
+					case <-runCtx.Done():
 					}
-					if ctx.Err() != nil {
+					if runCtx.Err() != nil {
 						break
 					}
 				}
@@ -390,7 +425,7 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 		for _, p := range pending {
 			select {
 			case jobs <- p:
-			case <-ctx.Done():
+			case <-runCtx.Done():
 				return
 			}
 		}
@@ -401,15 +436,25 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 	}()
 
 	done := 0
+	var consecutiveFailures int
+	var breakerTripped bool
 	for oc := range outcomes {
 		done++
 		if oc.err != nil {
 			res.Failed++ // chunk not marked — retried on the next run
+			if cfg.CircuitBreaker > 0 {
+				consecutiveFailures++
+				if consecutiveFailures >= cfg.CircuitBreaker && !breakerTripped {
+					breakerTripped = true
+					cancelRun()
+				}
+			}
 			if cfg.OnProgress != nil {
 				cfg.OnProgress(done, total, res)
 			}
 			continue
 		}
+		consecutiveFailures = 0
 		res.ChunksDistilled++
 
 		allowedIDs := make(map[int64]bool, len(oc.promptContext))
@@ -475,6 +520,9 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 		if cfg.OnProgress != nil {
 			cfg.OnProgress(done, total, res)
 		}
+	}
+	if breakerTripped {
+		return res, fmt.Errorf("%w after %d consecutive chunk failures", ErrCircuitBreaker, cfg.CircuitBreaker)
 	}
 	if ctx.Err() != nil {
 		return res, ctx.Err()

--- a/internal/distill/distill_test.go
+++ b/internal/distill/distill_test.go
@@ -606,3 +606,96 @@ func TestRunCtxCancellationDuringConcurrentRun(t *testing.T) {
 			res.ChunksDistilled, len(pending), res.ChunksDistilled+len(pending), n)
 	}
 }
+
+// TestRunCircuitBreakerStopsEarly models a persistent Ollama outage (quota
+// exhausted, endpoint down — not the transient 429 MaxRetries already
+// absorbs): every chunk fails every attempt. With Concurrency 1 the run is
+// deterministic, so once CircuitBreaker consecutive full-failures accrue,
+// Run must stop dispatching immediately rather than grinding through the
+// rest of the backlog at MaxRetries cost per chunk.
+func TestRunCircuitBreakerStopsEarly(t *testing.T) {
+	d := openTestDB(t)
+	const n = 20
+	for i := 0; i < n; i++ {
+		seedChunk(t, d, "chunk that always fails", "2026-07-01")
+	}
+	cli := &flakyDistiller{avail: true, failCount: 1_000_000}
+	res, err := Run(context.Background(), d, cli, Config{
+		Threshold: 0.7, ContextCap: 200, MaxRetries: 0, CircuitBreaker: 3,
+	})
+	if !errors.Is(err, ErrCircuitBreaker) {
+		t.Fatalf("err = %v, want ErrCircuitBreaker", err)
+	}
+	// Exactly 3 in the common case, but the dispatcher can race one more
+	// job into the (single, here) worker's receive loop before it observes
+	// the cancellation triggered by the 3rd failure — that job is already
+	// "in flight" by this package's stop-gracefully contract, so a small
+	// overshoot is expected, not a bug. What must never happen is draining
+	// anywhere near the full backlog.
+	if res.Failed < 3 || res.Failed > 5 {
+		t.Fatalf("res.Failed = %d, want 3-5 (stops shortly after the 3rd consecutive failure)", res.Failed)
+	}
+	if got := atomic.LoadInt64(&cli.calls); got >= n {
+		t.Fatalf("Distill called %d times, want well under %d (dispatch must stop, not drain the whole backlog)", got, n)
+	}
+	pending, err := db.ChunksWithoutFacts(d)
+	if err != nil || len(pending) != n {
+		t.Fatalf("pending after breaker trip = %+v err=%v, want all %d left for a later run", pending, err, n)
+	}
+}
+
+// TestRunCircuitBreakerResetsOnSuccess verifies a success anywhere in the
+// stream resets the consecutive-failure count — a breaker that counted
+// total failures instead of a streak would trip on a backlog that's mostly
+// fine but has scattered unrelated failures, which is not the "persistent
+// outage" signal it's meant to catch.
+func TestRunCircuitBreakerResetsOnSuccess(t *testing.T) {
+	d := openTestDB(t)
+	// Fail, fail, succeed, fail, fail, succeed, ... — never 3 in a row,
+	// even though 8 of 12 chunks fail overall (well past a naive total
+	// count of 3).
+	const n = 12
+	for i := 0; i < n; i++ {
+		seedChunk(t, d, "chunk", "2026-07-01")
+	}
+	var calls int64
+	cli := &fixedDistiller{avail: true, fn: func(string, []internal.Fact) ([]Candidate, error) {
+		n := atomic.AddInt64(&calls, 1)
+		if n%3 == 0 {
+			return []Candidate{{Subject: "s", Predicate: "p", Object: "o", Confidence: 0.9}}, nil
+		}
+		return nil, errors.New("simulated failure")
+	}}
+	res, err := Run(context.Background(), d, cli, Config{
+		Threshold: 0.7, ContextCap: 200, MaxRetries: 0, CircuitBreaker: 3,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v, want nil (breaker must not trip on a failure streak that never reaches 3)", err)
+	}
+	if res.ChunksDistilled != 4 || res.Failed != 8 {
+		t.Fatalf("res = %+v, want ChunksDistilled=4 Failed=8", res)
+	}
+	pending, err := db.ChunksWithoutFacts(d)
+	if err != nil || len(pending) != n-4 {
+		t.Fatalf("pending = %+v err=%v, want %d (only the successes marked)", pending, err, n-4)
+	}
+}
+
+// TestRunCircuitBreakerDisabledByDefault verifies CircuitBreaker's zero
+// value drains the whole backlog regardless of failure streak length,
+// preserving pre-circuit-breaker behavior for existing callers.
+func TestRunCircuitBreakerDisabledByDefault(t *testing.T) {
+	d := openTestDB(t)
+	const n = 10
+	for i := 0; i < n; i++ {
+		seedChunk(t, d, "chunk that always fails", "2026-07-01")
+	}
+	cli := &flakyDistiller{avail: true, failCount: 1_000_000}
+	res, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200, MaxRetries: 0})
+	if err != nil {
+		t.Fatalf("Run: %v, want nil (CircuitBreaker=0 must never trip)", err)
+	}
+	if res.Failed != n {
+		t.Fatalf("res.Failed = %d, want %d (every chunk attempted)", res.Failed, n)
+	}
+}


### PR DESCRIPTION
## Summary
- `distill.Config` gains `CircuitBreaker`: after N consecutive chunks each exhaust their retry budget and still fail, `Run` stops dispatching further work (in-flight chunks still allowed to finish) and returns `ErrCircuitBreaker` — distinguishes a persistent outage (Ollama cloud quota exhausted, endpoint down) from the transient blips `MaxRetries` already absorbs.
- `distill` CLI installs a SIGINT/SIGTERM handler so Ctrl-C stops the same way: no new dispatch, in-flight work drains, already-successful chunks stay marked. Exit code 2 for a circuit-breaker trip, 130 for an interrupt — both distinguishable from an ordinary error.
- `bin/distill-backfill.sh` (in `~/wrk/common`) passes through `--circuit-breaker` and stops the whole multi-project batch on exit 2/130 instead of looping into five more dead attempts against a downed endpoint.
- Resumability was already structural (`ChunksWithoutFacts` skips anything already marked `distilled_chunks`) — this PR is about stopping *cleanly* and *early* when it's pointless to keep going, not about adding new state to resume from.

## Why
Follow-up to #41. Once concurrency made the backlog fast to churn through, the next failure mode became: a dead/rate-limited Ollama endpoint burning through the *entire* remaining backlog at full retry cost (every chunk paying `MaxRetries` attempts with backoff) before finally finishing with nothing to show for it, with no way to stop cleanly mid-run.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./... -race -count=1` — 79/79 pass, distill package re-run 5x with `-race` for flakiness
- [x] New tests: breaker trips on N consecutive full-failures, resets on any success, disabled by default (0), and the existing concurrent-cancellation test still passes against the refactored `runCtx`
- [x] Manual e2e: circuit breaker against a stub Ollama that always 429s (stopped after 4/3921 chunks, exit 2); SIGTERM mid-run against live Ollama cloud (drained in-flight work, 13 chunks committed, exit 130); confirmed next invocation resumes with zero gap or re-processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)