### PR TITLE
fix(session-end): agy prompt was silently dropped via stdin, not read

### DIFF
--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -88,6 +88,16 @@ $EXCERPT"
 
 # --- LLM call helpers ---
 
+# is_valid_summary rejects anything that doesn't start with the expected
+# "## $TODAY" header — guards against a model ignoring the prompt and
+# returning generic chit-chat (observed: agy silently dropping the prompt
+# when passed via stdin, e.g. "I am currently running on Gemini 3.5
+# Flash..."). A non-empty result is not enough on its own; it must also
+# look like the summary we asked for, or the next tier should be tried.
+is_valid_summary() {
+  [[ "$1" == "## $TODAY"* ]]
+}
+
 try_agy() {
   local models=(
     "Gemini 3.5 Flash (Low)"
@@ -100,8 +110,12 @@ try_agy() {
   for model in "${models[@]}"; do
     echo "[$(date -Iseconds)] session-end: trying agy model: $model" >> "$LOG_FILE"
     local result
-    result=$(timeout 45 agy -p --model "$model" <<< "$1" 2>>"$LOG_FILE") && \
-      [[ -n "$result" ]] && { echo "$result"; return 0; }
+    # Prompt as a positional arg, not stdin — `agy -p` reads the prompt
+    # from its argument; piping via `<<<` leaves it unset and agy falls
+    # back to a generic interactive-style greeting instead of erroring.
+    result=$(timeout 45 agy -p "$1" --model "$model" 2>>"$LOG_FILE") && \
+      is_valid_summary "$result" && { echo "$result"; return 0; }
+    echo "[$(date -Iseconds)] session-end: agy model $model returned no usable summary" >> "$LOG_FILE"
   done
   return 1
 }
@@ -147,7 +161,8 @@ try_opencode() {
         map(select(. != null and .type == "text")) |
         map(.part.text) |
         join("")
-      ') && [[ -n "$result" ]] && { echo "$result"; return 0; }
+      ') && is_valid_summary "$result" && { echo "$result"; return 0; }
+    echo "[$(date -Iseconds)] session-end: opencode model $model returned no usable summary" >> "$LOG_FILE"
   done
   return 1
 }


### PR DESCRIPTION
## Summary
- `try_agy()` in `.claude/hooks/session-end.sh` piped the prompt via `<<< "$1"` but `agy -p` reads it from a positional argument, not stdin — so `agy` ignored the real prompt and returned generic filler instead of a session summary.
- The only success check was `[[ -n "$result" ]]`, so the filler got accepted and written into `.claude/session-log.md`, growing unbounded since it never matched the `## YYYY-MM-DD` header the rotation logic looks for.
- Fix: pass the prompt positionally, and add `is_valid_summary()` to reject anything not starting with the expected header, applied to both the `agy` and `opencode` tiers (this project's `opencode` tier uses `jq`, not `python3` — preserved as-is, targeted patch not a full overwrite).
- Same bug fixed in `~/wrk/common`'s canonical copy and other deployed copies.

## Test plan
- [x] `bash -n` syntax check passes
- [x] Live-tested the corrected `agy -p "$PROMPT" --model X` invocation — returns a properly headed summary instead of chit-chat
- [x] Diff reviewed — only the two success-check sites touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)