### PR TITLE
chore(fix-review): replace ad-hoc cli tier with canonical external_agents

### DIFF
--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -150,9 +150,16 @@ probe_provider() {
 # External-agent tier (own free tiers, independent of Ollama quota) —
 # optional, like the old cli block: an absent config key means there is
 # nothing to fail over to and a cloud outage aborts the run instead.
+# yq is the primary check; grep/awk fallback keeps Step 0 working on
+# hosts without yq (matching the yq-less fallback the script already
+# documents for the model-name reads a few lines below).
 EXTERNAL_AGENTS_EXIST="no"
-yq -e '.reviewers.external_agents' .claude/skills/fix-review/config.yaml >/dev/null 2>&1 \
-  && EXTERNAL_AGENTS_EXIST="yes"
+if command -v yq >/dev/null 2>&1; then
+  yq -e '.reviewers.external_agents' .claude/skills/fix-review/config.yaml >/dev/null 2>&1 \
+    && EXTERNAL_AGENTS_EXIST="yes"
+elif grep -q '^  external_agents:' .claude/skills/fix-review/config.yaml 2>/dev/null; then
+  EXTERNAL_AGENTS_EXIST="yes"
+fi
 
 if [ "$REVIEWER_SET" = "cloud" ] && ! probe_provider; then
   if [ "$EXTERNAL_AGENTS_EXIST" = "yes" ]; then
@@ -589,10 +596,26 @@ SPEEDUP=$(awk -v s="$SEQ_SUM_MS" -v w="$WALL_TIME_MS" \
 
 if [ "$ACTIVE_PROVIDER" = "external_agents" ]; then
   # Read back whichever tool actually won each round — round_N.meta line 1
-  # (set by try_external_agents / run_external_round's fallback).
-  MODELS_LIST="$(head -1 "$RUN_DIR/round_1.meta") | $(head -1 "$RUN_DIR/round_2.meta") | $(head -1 "$RUN_DIR/round_3.meta")"
+  # (set by try_external_agents / run_external_round's fallback). A round
+  # that fully failed gets a placeholder rather than the literal "none"
+  # string (which would otherwise show up in the summary as a "tool").
+  MODELS_LIST=""
+  for n in $(seq 1 "$NUM_ROUNDS"); do
+    [ -n "$MODELS_LIST" ] && MODELS_LIST+=" | "
+    t=$(head -1 "$RUN_DIR/round_${n}.meta" 2>/dev/null)
+    if [ "$t" = "none" ] || [ -z "$t" ]; then
+      MODELS_LIST+="(failed)"
+    else
+      MODELS_LIST+="$t"
+    fi
+  done
 else
-  MODELS_LIST="${MODEL_R1} | ${MODEL_R2} | ${MODEL_R3}"
+  MODELS_LIST=""
+  for n in $(seq 1 "$NUM_ROUNDS"); do
+    [ -n "$MODELS_LIST" ] && MODELS_LIST+=" | "
+    v="MODEL_R${n}"
+    MODELS_LIST+="${!v}"
+  done
 fi
 
 VOTE_BAND_REPORT=""
@@ -608,7 +631,25 @@ done
 
 FAILOVER_SECTION=""
 if [ -n "$FAILOVER_TIER" ]; then
-  agents_csv=$(for n in 1 2 3; do head -1 "$RUN_DIR/round_${n}.meta"; done | sort -u | paste -sd, -)
+  # List each round's winning tool, skipping fully-failed rounds (their
+  # meta line 1 is "none") and deduping so a 3-round cascade onto the
+  # same tool is shown as e.g. "omp x3" rather than just "omp" —
+  # matches MODELS_LIST's per-round fidelity in the summary above.
+  round_tools=""
+  for n in $(seq 1 "$NUM_ROUNDS"); do
+    t=$(head -1 "$RUN_DIR/round_${n}.meta" 2>/dev/null)
+    if [ "$t" != "none" ] && [ -n "$t" ]; then
+      round_tools+="$t"$'\n'
+    fi
+  done
+  agents_csv=$(printf '%s' "$round_tools" | awk '
+    NF { if (!seen[$0]++) order[++c]=$0; cnt[$0]++ }
+    END {
+      for (i=1; i<=c; i++) printf "%s%s x%d", (i==1?"":", "), order[i], cnt[order[i]]
+      print ""
+    }
+  ')
+  [ -z "$agents_csv" ] && agents_csv="(no tool returned output)"
   FAILOVER_SECTION=$(cat <<EOF
 
 ### ⚠️ Provider failover

--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -118,12 +118,11 @@ MODEL_R3=$(yq -r ".reviewers.${REVIEWER_BLOCK}.round_3.model // \"\"" .claude/sk
 
 If `yq` is not available, fall back to grep/awk.
 
-**Probe Ollama Cloud + CLI failover** (only when `REVIEWER_SET=cloud`):
+**Probe Ollama Cloud + external-agent failover** (only when `REVIEWER_SET=cloud`):
 
 ```bash
-ACTIVE_PROVIDER=ollama     # "ollama" | "cli"
-CLI_AGENTS=()              # name|cmd entries populated on failover
-FAILOVER_TIER=""           # "" | "cli"
+ACTIVE_PROVIDER=ollama     # "ollama" | "external_agents"
+FAILOVER_TIER=""           # "" | "external_agents"
 FAILOVER_REASON=""
 
 probe_provider() {
@@ -148,20 +147,22 @@ probe_provider() {
   return 0
 }
 
+# External-agent tier (own free tiers, independent of Ollama quota) —
+# optional, like the old cli block: an absent config key means there is
+# nothing to fail over to and a cloud outage aborts the run instead.
+EXTERNAL_AGENTS_EXIST="no"
+yq -e '.reviewers.external_agents' .claude/skills/fix-review/config.yaml >/dev/null 2>&1 \
+  && EXTERNAL_AGENTS_EXIST="yes"
+
 if [ "$REVIEWER_SET" = "cloud" ] && ! probe_provider; then
-  echo "⚠️  FAILOVER: Ollama Cloud unavailable (${FAILOVER_REASON}) — engaging CLI tier" >&2
-  count=$(yq '.reviewers.cli | length' .claude/skills/fix-review/config.yaml 2>/dev/null)
-  for ((i=0; i<count; i++)); do
-    name=$(yq -r ".reviewers.cli[$i].name" .claude/skills/fix-review/config.yaml)
-    cmd=$(yq -r  ".reviewers.cli[$i].cmd"  .claude/skills/fix-review/config.yaml)
-    CLI_AGENTS+=("${name}|${cmd}")
-  done
-  if [ "${#CLI_AGENTS[@]}" -eq 0 ]; then
-    echo "✗ CLI tier empty — cannot fail over. Aborting." >&2; exit 1
+  if [ "$EXTERNAL_AGENTS_EXIST" = "yes" ]; then
+    echo "⚠️  FAILOVER: Ollama Cloud unavailable (${FAILOVER_REASON}) — engaging external_agents tier" >&2
+    ACTIVE_PROVIDER=external_agents
+    FAILOVER_TIER=external_agents
+  else
+    echo "✗ Ollama Cloud unavailable (${FAILOVER_REASON}) and no external_agents tier configured — aborting." >&2
+    exit 1
   fi
-  ACTIVE_PROVIDER=cli
-  FAILOVER_TIER=cli
-  echo "⚠️  FAILOVER: using CLI tier ($(printf '%s ' "${CLI_AGENTS[@]%%|*}"))" >&2
 fi
 ```
 
@@ -366,27 +367,37 @@ run_round() {
     "${pt:-null}" "${ct:-null}" > "$RUN_DIR/round_${n}.meta"
 }
 
-run_cli_round() {
-  local n="$1" name="$2" cmd="$3"
-  local r_start r_end response
-  r_start=$(now_ms)
-  response=$(printf '%s' "$PROMPT" | timeout 300 sh -c "$cmd" 2>/dev/null) || response=""
-  r_end=$(now_ms)
-  printf '%s' "$response" > "$RUN_DIR/round_${n}.raw.txt"
-  printf '%s\n%s\n%s\n' "$name" "$((r_end - r_start))" "null null" \
-    > "$RUN_DIR/round_${n}.meta"
-}
-export -f run_round run_cli_round
+source .claude/skills/lib/agents.sh
 
-if [ "$ACTIVE_PROVIDER" = "cli" ]; then
-  n=1
-  for entry in "${CLI_AGENTS[@]}"; do
-    name="${entry%%|*}"; cmd="${entry#*|}"
-    run_cli_round "$n" "$name" "$cmd" &
-    n=$((n + 1))
-  done
+run_external_round() {
+  local n="$1"
+  local r_start r_end prompt_file
+  r_start=$(now_ms)
+  prompt_file=$(mktemp)
+  printf '%s\n\n%s' "$REVIEW_SYSTEM_MSG" "$PROMPT" > "$prompt_file"
+  if ! try_external_agents "$n" "$prompt_file" ".claude/skills/fix-review/config.yaml" "$RUN_DIR"; then
+    echo "✗ round ${n}: every external agent failed/empty — 0 findings" >&2
+    printf '[]' > "$RUN_DIR/round_${n}.raw.json"
+    printf 'none\n0\n' > "$RUN_DIR/round_${n}.meta"
+  fi
+  rm -f "$prompt_file"
+  r_end=$(now_ms)
+  # try_external_agents already wrote round_${n}.meta with duration "0" on
+  # success — fix up the timing half now the real elapsed time is known.
+  if [ -f "$RUN_DIR/round_${n}.failover" ]; then
+    local winning_tool; winning_tool=$(head -1 "$RUN_DIR/round_${n}.meta")
+    printf '%s\n%s\n' "$winning_tool" "$((r_end - r_start))" > "$RUN_DIR/round_${n}.meta"
+  fi
+}
+export -f run_round run_external_round rest_post now_ms run_external_agent \
+  try_external_agents agent_cursor_agent agent_omp agent_codex agent_opencode agent_kilo
+
+if [ "$ACTIVE_PROVIDER" = "external_agents" ]; then
+  run_external_round 1 &
+  run_external_round 2 &
+  run_external_round 3 &
   wait
-  NUM_ROUNDS=$((n - 1))
+  NUM_ROUNDS=3
 else
   run_round 1 "$MODEL_R1" &
   run_round 2 "$MODEL_R2" &
@@ -400,9 +411,20 @@ WALL_TIME_MS=$((WALL_END_MS - WALL_START_MS))
 ```
 
 > If `export -f` doesn't propagate (older bash, restricted shells), inline
-> the `run_round` body inside `bash -c '...' &` blocks. Contract: each
-> background job writes `round_N.raw.json` + `round_N.meta`
-> (3 lines: `model\nduration_ms\nprompt_tokens completion_tokens`).
+> the `run_round`/`run_external_round` bodies inside `bash -c '...' &`
+> blocks. Contract: each background job writes `round_N.raw.json` +
+> `round_N.meta` (Ollama rounds: 3 lines — `model\nduration_ms\nprompt_tokens
+> completion_tokens`; external_agents rounds: 2 lines — `tool\nduration_ms`,
+> no token counts since these tools don't report them).
+>
+> **Failover chain**: unlike per-round cascading, session-indexer decides
+> `ACTIVE_PROVIDER` once for the whole run at Step 0 (a single upfront
+> probe, not per-round) — if cloud is down, all three rounds go through
+> `try_external_agents`, which walks `reviewers.external_agents` in
+> config order and keeps the first tool that returns non-empty output.
+> Each round cascades independently starting from the same tool[0], so a
+> full outage can converge all three rounds onto the same external tool
+> — degraded diversity, but still a real review instead of zero coverage.
 
 ---
 
@@ -413,8 +435,11 @@ parse_round() {
   local n="$1"
   local model content
   model=$(head -1 "$RUN_DIR/round_${n}.meta")
-  if [ "$ACTIVE_PROVIDER" = "cli" ]; then
-    content=$(cat "$RUN_DIR/round_${n}.raw.txt")
+  if [ "$ACTIVE_PROVIDER" = "external_agents" ]; then
+    # try_external_agents already unwraps each tool's own output envelope —
+    # round_${n}.raw.json holds plain extracted text, not an Ollama
+    # {"message":{"content":...}} wrapper.
+    content=$(cat "$RUN_DIR/round_${n}.raw.json")
   else
     content=$(jq -r '.message.content // empty' "$RUN_DIR/round_${n}.raw.json")
   fi
@@ -562,8 +587,10 @@ done
 SPEEDUP=$(awk -v s="$SEQ_SUM_MS" -v w="$WALL_TIME_MS" \
   'BEGIN{ if (w>0) printf "%.2f", s/w; else print "n/a" }')
 
-if [ "$ACTIVE_PROVIDER" = "cli" ]; then
-  MODELS_LIST=$(printf '%s | ' "${CLI_AGENTS[@]%%|*}" | sed 's/ | $//')
+if [ "$ACTIVE_PROVIDER" = "external_agents" ]; then
+  # Read back whichever tool actually won each round — round_N.meta line 1
+  # (set by try_external_agents / run_external_round's fallback).
+  MODELS_LIST="$(head -1 "$RUN_DIR/round_1.meta") | $(head -1 "$RUN_DIR/round_2.meta") | $(head -1 "$RUN_DIR/round_3.meta")"
 else
   MODELS_LIST="${MODEL_R1} | ${MODEL_R2} | ${MODEL_R3}"
 fi
@@ -581,7 +608,7 @@ done
 
 FAILOVER_SECTION=""
 if [ -n "$FAILOVER_TIER" ]; then
-  agents_csv=$(printf '%s, ' "${CLI_AGENTS[@]%%|*}" | sed 's/, $//')
+  agents_csv=$(for n in 1 2 3; do head -1 "$RUN_DIR/round_${n}.meta"; done | sort -u | paste -sd, -)
   FAILOVER_SECTION=$(cat <<EOF
 
 ### ⚠️ Provider failover
@@ -592,7 +619,7 @@ Reason:    ${FAILOVER_REASON}
 Agents:    ${agents_csv}
 
 Action: regenerate OLLAMA_API_KEY at https://ollama.com/settings/keys
-or adjust reviewers.cli in config.yaml.
+or adjust reviewers.external_agents in config.yaml.
 EOF
 )
 fi

--- a/.claude/skills/fix-review/config.yaml
+++ b/.claude/skills/fix-review/config.yaml
@@ -45,19 +45,26 @@ reviewers:
     round_3:
       model: granite3.3:8b      # local, no subscription needed
 
-  # CLI failover tier — engaged automatically when Ollama Cloud probe fails
-  # (401 invalid key, 429 quota exceeded, network error). Each agent is
-  # invoked in parallel (independent processes — no shared-engine
-  # bottleneck). The review prompt is piped to stdin; stdout is captured
-  # as the response. Non-JSON output or non-zero exit → 0 findings for
-  # that round (the whole run still proceeds). Per-agent timeout: 300s.
-  cli:
-    - { name: opencode,     cmd: "sh -c 'opencode run -m opencode/nemotron-3-super-free --format json \"$(cat)\"'" }
-    - { name: gemini,       cmd: "gemini --model gemini-2.5-flash-lite" }
-    - { name: codex,        cmd: "codex --dangerously-bypass-approvals-and-sandbox review -" }
-    - { name: cursor-agent, cmd: "cursor-agent --model auto" }
-    - { name: kilo,         cmd: "sh -c 'kilo run \"$(cat)\"'" }
-    - { name: agy,          cmd: "agy --print --model 'GPT-OSS 120B (Medium)' --dangerously-skip-permissions" }
+  # External-agent failover tier — engaged automatically when Ollama Cloud
+  # probe fails (401 invalid key, 429 quota exceeded, network error).
+  # Cascaded in this order via lib/agents.sh's try_external_agents (first
+  # tool that returns non-empty output wins); each adapter is invoked
+  # read-only (no edits, no shell execution) — see lib/agents.sh for the
+  # exact per-tool flags. Replaces the old ad-hoc reviewers.cli block
+  # (migrated 2026-08-20 per ~/wrk/common/skills/fix-review/lib/agents.sh,
+  # commit c6c0698): agy was dropped (evaluated 2026-07-29 — explores the
+  # filesystem instead of answering, in both --mode plan and unrestricted
+  # modes, not a prompt-wording problem); gemini was dropped (unverified,
+  # no canonical adapter — was never actually exercised as a failover
+  # path); codex now runs with --sandbox read-only instead of
+  # --dangerously-bypass-approvals-and-sandbox (full write access was
+  # never needed for a read-only reviewer).
+  external_agents:
+    - { tool: cursor-agent, model: auto }
+    - { tool: omp }
+    - { tool: codex }
+    - { tool: opencode, model: "opencode/nemotron-3-ultra-free" }
+    - { tool: kilo }
 
 # ---------------------------------------------------------------------------
 # Reviewer set (which reviewers.* block above to load)

--- a/.claude/skills/lib/agents.sh
+++ b/.claude/skills/lib/agents.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# lib/agents.sh — external coding-agent CLI adapters for /fix-review tier 2
+#
+# Usage:
+#   source .claude/skills/lib/agents.sh
+#
+#   OUT=$(run_external_agent "cursor-agent" "auto" "$PROMPT_FILE")
+#   try_external_agents 1 "$PROMPT_FILE" "$CONFIG"   # cascades the ordered
+#                                                     # reviewers.external_agents
+#                                                     # list from config.yaml
+#
+# Each of cursor-agent/omp/codex/opencode/kilo is invoked read-only
+# (no edits, no shell execution) and already unwraps its own tool-specific
+# output envelope, so callers get plain text back — the SAME code-fence-strip
+# + JSON-array-validate logic already used for Ollama responses (see
+# fix-review/SKILL.md STEP 4 parse_round()) works unchanged downstream.
+#
+# All prompt content is piped via stdin/file-ref, never a shell argument —
+# PR diffs can be large enough to risk ARG_MAX.
+#
+# `agy` was evaluated and dropped: even with the full review prompt (not
+# just a throwaway one-liner) it consistently explores the filesystem/
+# environment instead of answering directly, in both --mode plan and
+# unrestricted modes. Not a prompt-wording problem — verified 2026-07-29.
+
+# ---------------------------------------------------------------------------
+# Per-tool adapters — read-only invocation + envelope extraction, verified
+# against real calls with a realistic review prompt (not just --help docs).
+# ---------------------------------------------------------------------------
+
+agent_cursor_agent() {
+  local model="$1" prompt_file="$2"
+  cursor-agent --print --output-format json --mode plan \
+    ${model:+--model "$model"} < "$prompt_file" \
+    | jq -r '.result // empty'
+}
+
+agent_omp() {
+  local model="$1" prompt_file="$2"
+  # omp's own "@file" syntax for message content (not stdin).
+  omp -p --mode json --no-tools ${model:+--model "$model"} "@$prompt_file" \
+    | jq -rs '[.[] | select(.type=="message_update") | .assistantMessageEvent
+               | select(.type=="text_end") | .content] | last // empty'
+}
+
+agent_codex() {
+  local model="$1" prompt_file="$2"
+  # Plain-text output with a banner + echoed prompt around the answer;
+  # take the last line that looks like a JSON array (codex prints the
+  # final answer twice — once inline, once in a closing summary).
+  codex exec --sandbox read-only ${model:+-m "$model"} - < "$prompt_file" 2>/dev/null \
+    | awk '/^\[/' | tail -1
+}
+
+agent_opencode() {
+  local model="$1" prompt_file="$2"
+  # No default model on this install — always pass one explicitly or the
+  # call errors out (verified 2026-07-29). config.yaml must set a model
+  # for this tool.
+  opencode run --format json ${model:+--model "$model"} < "$prompt_file" \
+    | jq -rs '[.[] | select(.type=="text")] | last | .part.text // empty'
+}
+
+agent_kilo() {
+  local model="$1" prompt_file="$2"
+  # Same CLI/event shape as opencode (fork/whitelabel of the same project),
+  # but has a working default model — --model stays optional.
+  kilo run --format json ${model:+--model "$model"} < "$prompt_file" \
+    | jq -rs '[.[] | select(.type=="text")] | last | .part.text // empty'
+}
+
+# ---------------------------------------------------------------------------
+# Dispatcher + cascade
+# ---------------------------------------------------------------------------
+
+# Usage: run_external_agent "<tool>" "<model-or-empty>" "<prompt-file>"
+# Prints extracted text to stdout. Empty output == failure for this tool.
+run_external_agent() {
+  local tool="$1" model="$2" prompt_file="$3"
+  case "$tool" in
+    cursor-agent) agent_cursor_agent "$model" "$prompt_file" ;;
+    omp)          agent_omp          "$model" "$prompt_file" ;;
+    codex)        agent_codex        "$model" "$prompt_file" ;;
+    opencode)     agent_opencode     "$model" "$prompt_file" ;;
+    kilo)         agent_kilo         "$model" "$prompt_file" ;;
+    *)
+      echo "warn: unknown external agent tool '$tool' — skipping" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Usage: try_external_agents <round-n> <prompt-file> <config-path> <run-dir>
+# Walks reviewers.external_agents in config.yaml order; first tool that
+# returns non-empty output wins. Writes round_${n}.raw.json / .meta /
+# .failover on success (same marker-file convention SKILL.md STEP 3/11
+# already use for the ollama_local tier). Returns 1 if every tool failed
+# (or the config key is absent) so the caller falls through to ollama_local.
+try_external_agents() {
+  local n="$1" prompt_file="$2" config="$3" run_dir="$4"
+  local entry tool model out
+
+  # Read the config list on fd 3, not stdin — several adapters (cursor-agent,
+  # codex, opencode) read their prompt from stdin, and a `while read` loop
+  # driven by stdin would otherwise race/interleave with those inner reads
+  # (confirmed empirically: without this, a tool mid-loop got truncated
+  # input because it silently shared the loop's stdin stream).
+  while IFS= read -r entry <&3; do
+    [ -z "$entry" ] && continue
+    tool=$(jq -r '.tool' <<<"$entry")
+    model=$(jq -r '.model // empty' <<<"$entry")
+    echo "warn: round ${n} trying external agent ${tool}${model:+ ($model)}" >&2
+    out=$(run_external_agent "$tool" "$model" "$prompt_file" 2>/dev/null </dev/null)
+    if [ -n "$(printf '%s' "$out" | tr -d '[:space:]')" ]; then
+      printf '%s' "$out" > "$run_dir/round_${n}.raw.json"
+      printf '%s\n0' "$tool" > "$run_dir/round_${n}.meta"
+      printf 'external_agents:%s' "$tool" > "$run_dir/round_${n}.failover"
+      return 0
+    fi
+    echo "warn: round ${n} external agent ${tool} failed/empty — trying next" >&2
+  done 3< <(yq -c '.reviewers.external_agents[]' "$config" 2>/dev/null)
+
+  return 1
+}


### PR DESCRIPTION
## Summary
- Replace the ad-hoc `reviewers.cli` block (6 CLI tools wired directly into `SKILL.md`'s control flow) with the canonical `external_agents` pattern from `~/wrk/common/skills/fix-review/lib/agents.sh` (commit `c6c0698`).
- Fixes two safety regressions: `codex` now runs `--sandbox read-only` instead of `--dangerously-bypass-approvals-and-sandbox`; `agy` is dropped (evaluated by canonical as unreliable — explores the filesystem instead of answering) instead of running with `--dangerously-skip-permissions`.
- `gemini` also dropped (never evaluated, no canonical adapter).
- Preserves session-indexer's own upfront (not per-round) failover-decision architecture, and its `think`/`diff_scope`/PR-comment-formatting project-specific logic.

Per `~/wrk/common/tmp/fix-review-group-a-replace-github-pages-lance-agent-session-indexer.md`.

## Test plan
- [x] `config.yaml` validated as YAML, `external_agents` key readable via `yq`
- [x] `agents.sh` syntax-checked (`bash -n`), all 5 referenced tools present on PATH
- [ ] Force a round's cloud model invalid, verify cascade into `external_agents`, confirm Step 11 summary names the winning tool correctly, then revert (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)