### PR TITLE
chore(fix-review): add agy to external_agents tier

### DIFF
--- a/.claude/skills/fix-review/config.yaml
+++ b/.claude/skills/fix-review/config.yaml
@@ -52,15 +52,19 @@ reviewers:
   # read-only (no edits, no shell execution) — see lib/agents.sh for the
   # exact per-tool flags. Replaces the old ad-hoc reviewers.cli block
   # (migrated 2026-08-20 per ~/wrk/common/skills/fix-review/lib/agents.sh,
-  # commit c6c0698): agy was dropped (evaluated 2026-07-29 — explores the
-  # filesystem instead of answering, in both --mode plan and unrestricted
-  # modes, not a prompt-wording problem); gemini was dropped (unverified,
-  # no canonical adapter — was never actually exercised as a failover
-  # path); codex now runs with --sandbox read-only instead of
+  # commit c6c0698): agy was initially dropped on a misdiagnosis (the
+  # `--prompt "text"` invocation silently dropped the prompt because
+  # `--prompt` is a `--print` alias, not a value-taking option — agy
+  # explored the filesystem because it had no real task; the positional
+  # `-p "$(cat ...)"` form, verified 2026-07-30, restores its expected
+  # structured-JSON output and is now included); gemini was dropped
+  # (unverified, no canonical adapter — was never actually exercised as a
+  # failover path); codex now runs with --sandbox read-only instead of
   # --dangerously-bypass-approvals-and-sandbox (full write access was
   # never needed for a read-only reviewer).
   external_agents:
     - { tool: cursor-agent, model: auto }
+    - { tool: agy, model: "Gemini 3.5 Flash (Low)" }
     - { tool: omp }
     - { tool: codex }
     - { tool: opencode, model: "opencode/nemotron-3-ultra-free" }

--- a/.claude/skills/fix-review/config.yaml
+++ b/.claude/skills/fix-review/config.yaml
@@ -52,14 +52,19 @@ reviewers:
   # read-only (no edits, no shell execution) — see lib/agents.sh for the
   # exact per-tool flags. Replaces the old ad-hoc reviewers.cli block
   # (migrated 2026-08-20 per ~/wrk/common/skills/fix-review/lib/agents.sh,
-  # commit c6c0698): agy was initially dropped on a misdiagnosis (the
-  # `--prompt "text"` invocation silently dropped the prompt because
-  # `--prompt` is a `--print` alias, not a value-taking option — agy
-  # explored the filesystem because it had no real task; the positional
-  # `-p "$(cat ...)"` form, verified 2026-07-30, restores its expected
-  # structured-JSON output and is now included); gemini was dropped
-  # (unverified, no canonical adapter — was never actually exercised as a
-  # failover path); codex now runs with --sandbox read-only instead of
+  # commit c6c0698): agy needs the prompt as a positional argument after
+  # `-p`, not via stdin (verified — stdin-only returns a generic greeting
+  # instead of answering) and not as the value of `--prompt`/`-p` (both
+  # are --print boolean aliases per `agy --help`; verified empirically
+  # 2026-07-30 that agy takes the trailing positional as its operand
+  # regardless of which alias triggered --print mode). The canonical
+  # `session-end.sh:try_agy()` pattern `agy -p "$(cat ...)" --model ...
+  # --mode plan` is what we use here, with display-form model names like
+  # "Gemini 3.5 Flash (Low)" accepted by agy verbatim. agy was
+  # initially excluded on the wrong assumption that --prompt vs -p
+  # behaved differently; gemini was dropped (unverified, no canonical
+  # adapter — was never actually exercised as a failover path); codex
+  # now runs with --sandbox read-only instead of
   # --dangerously-bypass-approvals-and-sandbox (full write access was
   # never needed for a read-only reviewer).
   external_agents:

--- a/.claude/skills/lib/agents.sh
+++ b/.claude/skills/lib/agents.sh
@@ -35,6 +35,17 @@ agent_cursor_agent() {
     | jq -r '.result // empty'
 }
 
+agent_agy() {
+  local model="$1" prompt_file="$2"
+  # Unlike every other adapter here, the prompt MUST be a positional
+  # argument, not stdin/file-ref — verified 2026-07-30. --prompt is an
+  # alias for the --print boolean flag, not a value-taking option; the
+  # actual prompt text goes after -p as a trailing positional argument.
+  agy -p "$(cat "$prompt_file")" --model "${model:-Gemini 3.5 Flash (Low)}" \
+    --mode plan --output-format json 2>/dev/null \
+    | jq -r '.response // empty'
+}
+
 agent_omp() {
   local model="$1" prompt_file="$2"
   # omp's own "@file" syntax for message content (not stdin).
@@ -79,6 +90,7 @@ run_external_agent() {
   local tool="$1" model="$2" prompt_file="$3"
   case "$tool" in
     cursor-agent) agent_cursor_agent "$model" "$prompt_file" ;;
+    agy)          agent_agy          "$model" "$prompt_file" ;;
     omp)          agent_omp          "$model" "$prompt_file" ;;
     codex)        agent_codex        "$model" "$prompt_file" ;;
     opencode)     agent_opencode     "$model" "$prompt_file" ;;

--- a/.claude/skills/lib/agents.sh
+++ b/.claude/skills/lib/agents.sh
@@ -37,10 +37,14 @@ agent_cursor_agent() {
 
 agent_agy() {
   local model="$1" prompt_file="$2"
-  # Unlike every other adapter here, the prompt MUST be a positional
-  # argument, not stdin/file-ref — verified 2026-07-30. --prompt is an
-  # alias for the --print boolean flag, not a value-taking option; the
-  # actual prompt text goes after -p as a trailing positional argument.
+  # Pass the prompt as a trailing positional argument after `-p`. agy's
+  # `-p` (and `--prompt`) are --print aliases in --help, but the actual
+  # positional-argument semantics take the prompt text as their operand —
+  # the same pattern session-end.sh's try_agy() has been using in
+  # production. Stdin-only invocation does NOT work (agy returns a
+  # generic 'I am currently running on ...' greeting instead of answering
+  # the prompt — verified 2026-07-30). `$(cat file)` strips any trailing
+  # newline from the prompt; agy ignores that for prompt content.
   agy -p "$(cat "$prompt_file")" --model "${model:-Gemini 3.5 Flash (Low)}" \
     --mode plan --output-format json 2>/dev/null \
     | jq -r '.response // empty'


### PR DESCRIPTION
## Summary
- `lib/agents.sh`: add `agent_agy()` adapter (positional `-p "$(cat ...)"` form — `--prompt` was a `--print` alias, prompt was being silently dropped) and register `agy)` in `run_external_agent()`'s dispatcher case.
- `config.yaml`: insert `{ tool: agy, model: "Gemini 3.5 Flash (Low)" }` second in `external_agents:`. Fix the pre-existing comment block that still claimed agy was dropped — factually wrong post-rollout and now actively misleading.

Per `~/wrk/common/tmp/fix-review-agy-rollout-shared.md`.

## Test plan
- [x] `bash -n .claude/skills/lib/agents.sh` — syntax OK
- [x] `yq -c '.reviewers.external_agents[]' .claude/skills/fix-review/config.yaml` — 6 entries, agy appears second with model "Gemini 3.5 Flash (Low)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)