### PR TITLE
fix(deps): bump go 1.26.5 -> 1.26.6, fixes 4 stdlib CVEs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Tombstone resolution is filter-based (`WHERE until IS NULL`), not chain-walking.
 ## Key Constraints
 
 - **Pure Go, no CGO.** `go build` must produce a portable static binary.
-- **Go 1.26.5+.** Use `go 1.26.5` in `go.mod` (patch-pinned — `1.26.4` had GO-2026-5856, a `crypto/tls` ECH privacy leak fixed in `1.26.5`; see issue #31).
+- **Go 1.26.6+.** Use `go 1.26.6` in `go.mod` (patch-pinned — `1.26.5` had four stdlib CVEs reachable via `internal/distill`'s HTTP client: GO-2026-6218, GO-2026-6090, GO-2026-5972, GO-2026-5026, all fixed in `1.26.6`; see issue #31 for the prior GO-2026-5856 precedent that established this patch-pinning practice).
 - **60-second budget.** `mine` runs inside a Claude Code Stop hook. Must complete well within 60s (enforced internally via a 50s `context.Context` deadline — see Embeddings).
 - **Mixed Ukrainian + English content.** `bge-m3` handles both; `unicode61 remove_diacritics 0` tokenizer for FTS5.
 - **Per-project isolation.** No cross-project search, no shared state.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/valpere/session-indexer
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
## Summary
- Bump `go.mod`'s `go` directive from `1.26.5` to `1.26.6`, fixing 4 reachable stdlib CVEs (GO-2026-6218, GO-2026-6090, GO-2026-5972, GO-2026-5026) surfaced by `govulncheck` — all reachable via `internal/distill/distill.go`'s HTTP client.
- Update `CLAUDE.md`'s Go-version line to match, following the same patch-pinning precedent as #31 (GO-2026-5856).

Fixes #50.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -race ./...` — all packages pass
- [x] `govulncheck ./...` — no vulnerabilities found (was 4 before the bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)