### PR TITLE
docs: add CONTRIBUTING.md, fix stale go1.26.5 references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing
+
+session-indexer is a solo-maintained project, but issues, bug reports, and
+pull requests are welcome.
+
+## Before opening an issue
+
+Check the [FAQ](README.md#faq) and [Troubleshooting](README.md#troubleshooting)
+sections of the README first — most "why doesn't X work" questions are
+answered there (Ollama unavailable, schema version mismatch, worktree DB
+visibility, etc).
+
+For bug reports, include:
+- `session-indexer` version (`session-indexer --version`)
+- The command you ran and its full output
+- Go version (`go version`) and OS
+
+## Development setup
+
+```bash
+git clone https://github.com/valpere/session-indexer
+cd session-indexer
+go build -o bin/session-indexer ./cmd/session-indexer   # or: make build
+go test ./...                                            # or: make test
+go vet ./...                                              # or: make vet
+gofmt -l .                                                # should print nothing
+```
+
+Requires Go 1.26.6+ (see `go.mod`) and, for embedding-related work, a local
+[Ollama](https://ollama.com/download) with `bge-m3:latest` pulled. Tests that
+don't touch `internal/embed` run without Ollama.
+
+Run `make help` for the full list of Makefile targets.
+
+## Making a change
+
+1. Fork the repo and branch from `main`.
+2. Keep changes focused — one logical change per PR. Match the existing
+   style in the package you're touching (see `CLAUDE.md` for the project's
+   own architecture notes and conventions if you want the fuller picture).
+3. Add or update tests for any behavior change. `go test -race ./...` must
+   pass.
+4. Update `docs/architecture.md` or `docs/requirements.md` if your change
+   affects them — stale docs are worse than no docs.
+5. Open a PR against `main` with a clear description of what changed and
+   why. Reference any related issue.
+
+## Code review
+
+This repo uses an automated multi-model review pipeline
+(`.claude/skills/fix-review/`) for PRs opened via Claude Code. If you're
+contributing from outside that workflow, a manual review by the maintainer
+covers the same ground — no special process required on your end.
+
+## Reporting a security issue
+
+Please **do not** open a public issue for a security vulnerability. See
+[`SECURITY.md`](.github/SECURITY.md) if present, or open a private
+[security advisory](https://github.com/valpere/session-indexer/security/advisories/new)
+on GitHub instead.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under
+the project's [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ can break another.
 
 ## Prerequisites
 
-- **Go 1.26.5+** — to build the binary
+- **Go 1.26.6+** — to build the binary
 - **Ollama** — for vector embeddings (optional but recommended)
   - Install: [ollama.com/download](https://ollama.com/download) — native packages for macOS, Linux, Windows
   - `ollama pull bge-m3:latest` — 1024-dim multilingual model (EN + UA)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -449,7 +449,7 @@ session-indexer/
 │   │   └── _lib/hook-common.sh  — logging + shared session-log.md rotation (jq/bash, no python3)
 │   ├── settings.local.json
 ├── .gitignore
-├── go.mod                   — go 1.26.5
+├── go.mod                   — go 1.26.6
 └── Makefile
 ```
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -137,7 +137,7 @@ both languages with equivalent quality.
 
 ## Constraints
 
-- Go 1.26.5+ (project language; patch-pinned in `go.mod` — `1.26.4` had GO-2026-5856, a `crypto/tls` ECH privacy leak fixed in `1.26.5`; see issue #31)
+- Go 1.26.6+ (project language; patch-pinned in `go.mod` — `1.26.5` had four stdlib CVEs reachable via `internal/distill`'s HTTP client, fixed in `1.26.6`; see issues #31 and #50)
 - SQLite via `modernc.org/sqlite` (pure Go, no CGO)
 - Ollama local: `bge-m3:latest` for embeddings (1024 dims)
 - Claude Code JSONL format: lines of JSON, `type` field discriminates records; `sessionId` field present in each record (used as session_id; fall back to filename stem if absent)


### PR DESCRIPTION
## Summary
- Add `CONTRIBUTING.md` (solo-maintainer project — OSS-credibility cheap win from the Product Hunt launch-readiness audit).
- Fix 3 stale `go 1.26.5` references left behind by #51's narrowly-scoped diff: `README.md` Prerequisites, `docs/requirements.md` Constraints, `docs/architecture.md` file tree.

Docs-only diff — no gates to run beyond `go build`/`go vet` sanity (both clean, unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)