### PR TITLE
chore(ci): add scheduled trigger to govulncheck workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,7 +7,10 @@ on:
     branches: [main]
   schedule:
     # Weekly, off-peak, off a round number to avoid shared-runner congestion.
-    # Runs against the default branch (main) automatically.
+    # Runs against the default branch (main) automatically. GitHub disables
+    # scheduled workflows on public repos after 60 days with no repository
+    # activity — low risk here given the active PR/Dependabot cadence, but
+    # worth knowing if this job ever silently stops running.
     - cron: '17 6 * * 1'
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Weekly, off-peak, off a round number to avoid shared-runner congestion.
+    # Runs against the default branch (main) automatically.
+    - cron: '17 6 * * 1'
 
 jobs:
   vulncheck:


### PR DESCRIPTION
## Summary
- Add a weekly `schedule:` trigger (`cron: '17 6 * * 1'`, Monday 06:17 UTC) to `.github/workflows/security.yml`'s `vulncheck` job, alongside the existing `push`/`pull_request` triggers.
- Closes a gap where a newly disclosed stdlib CVE against the pinned Go patch version sat unnoticed until the next unrelated PR/push happened to trigger the job (as happened twice: #31 / GO-2026-5856, and #50 / PR #51).
- `schedule`-triggered workflows always run against the default branch, so no `branches:` filter changes were needed.
- No new failure-visibility mechanism added (e.g. no auto-issue-on-failure) — a red scheduled run in the Actions tab is the existing signal, per issue scope.

## Test plan
- [x] `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/security.yml'))"` — YAML valid
- [x] `go vet ./...` — pass
- [x] `go test -race ./...` — 79 tests pass, 8 packages (unaffected, no Go files touched)
- [x] static-analysis review (yamllint) — clean, no new warnings
- [x] Manual security review — no new permissions/secrets/steps introduced; `permissions: contents: read` unchanged

Closes https://github.com/valpere/session-indexer/issues/52

🤖 Generated with [Claude Code](https://claude.com/claude-code)