### PR TITLE
feat(db): record embedding model per row; re-embed on model change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ Schema version stored in `meta` table (`key='schema_version'`). On open: if vers
 
 Dedup key: `UNIQUE(session_id, message_index, chunk_index)` — `INSERT OR IGNORE` makes `mine` idempotent.
 
+`embeddings` rows carry a `model` column, tagged `"<provider>:<model>"` (e.g. `ollama:bge-m3:latest`) via `embed.ModelTag`. Search filters to the currently configured model's rows only and warns (doesn't silently mis-score) when other-model rows exist — `cosine()` can't tell "genuinely dissimilar" from "wrong dimensionality." `embed.ModelTag`/`ChunksNeedingEmbedding` (`internal/db/db.go`) mean switching the embedding model or provider no longer requires a DB wipe: `session-indexer embed` re-embeds the foreign-model rows in place.
+
 ### JSONL Parsing
 
 Extract `user` and `assistant` turns where `isMeta=false`. Skip XML/HTML (`<`), slash commands (`/\w+`), and content <30 chars after stripping. Truncate any single tool block to 2KB. Chunk messages at 1500 chars on paragraph boundaries.

--- a/cmd/session-indexer/main.go
+++ b/cmd/session-indexer/main.go
@@ -86,7 +86,8 @@ func main() {
 				return err
 			}
 			defer d.Close()
-			res, used, err := search.Search(d, embed.NewClient(), args[0], limit)
+			emb := embed.NewClient()
+			res, used, err := search.Search(d, emb, args[0], limit)
 			if err != nil {
 				return err
 			}
@@ -97,6 +98,24 @@ func main() {
 					fmt.Fprintf(os.Stderr,
 						"warn: %d chunks not yet embedded — results may be incomplete; run: session-indexer embed --db %s\n",
 						st.Pending, dbPath)
+				}
+				// Warn when rows exist under a different model tag than the
+				// one currently configured — cosineSearch filters those out
+				// entirely rather than silently mis-scoring them, so they're
+				// invisible to search until `embed` re-embeds them.
+				if models, e := db.EmbeddingModels(d); e == nil {
+					current := embed.ModelTag(emb)
+					var otherCount int
+					for _, mc := range models {
+						if mc.Model != current {
+							otherCount += mc.Count
+						}
+					}
+					if otherCount > 0 {
+						fmt.Fprintf(os.Stderr,
+							"warn: %d chunks embedded with a different model (current: %s) — excluded from results; run: session-indexer embed --db %s\n",
+							otherCount, current, dbPath)
+					}
 				}
 			}
 			return printResults(res, used, asJSON)
@@ -136,6 +155,9 @@ func main() {
 			}
 			fmt.Printf("Sessions indexed: %d\nChunks total:     %d\nWith embeddings:  %d (%d pending)\nFacts current:    %d\nPending distill:  %d\nOldest entry:     %s\nNewest entry:     %s\nDB size:          %s\n",
 				st.Sessions, st.Chunks, st.Embedded, st.Pending, st.Facts, st.PendingDistill, st.Oldest, st.Newest, st.DBSize)
+			for _, mc := range st.EmbeddingModels {
+				fmt.Printf("  embedding model: %-30s %d chunks\n", mc.Model, mc.Count)
+			}
 			return nil
 		},
 	}
@@ -321,7 +343,8 @@ func runEmbed(dbPath string) error {
 	if !emb.Available() {
 		return fmt.Errorf("ollama unavailable — start it and pull bge-m3:latest")
 	}
-	pending, err := db.ChunksWithoutEmbeddings(d)
+	modelTag := embed.ModelTag(emb)
+	pending, err := db.ChunksNeedingEmbedding(d, modelTag)
 	if err != nil {
 		return err
 	}
@@ -332,7 +355,7 @@ func runEmbed(dbPath string) error {
 			failed++
 			continue
 		}
-		if err := db.InsertEmbedding(d, p.ID, embed.EncodeVector(vec)); err != nil {
+		if err := db.InsertEmbedding(d, p.ID, embed.EncodeVector(vec), modelTag); err != nil {
 			failed++
 			continue
 		}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -408,6 +408,8 @@ pull the distill model (OLLAMA_DISTILL_MODEL)`, matching NFR-1.
 
 **2026-07-18** — Added the facts layer (`distill`, `facts search/get/related/supersede`), `SchemaVersion` "1" → "2". Existing DBs must be deleted and re-mined (no migration framework, by design — see NFR-2).
 
+**2026-08-24** — Added a `model` column to `embeddings`, `SchemaVersion` "2" → "3". Existing DBs must be deleted and re-mined (same policy as above). Prerequisite for supporting a second embedding provider (OpenRouter, alongside Ollama): search now filters to the currently configured model's rows and warns on a mismatch instead of silently mis-scoring vectors of a different dimensionality; `session-indexer embed` re-embeds foreign-model rows in place, so a *future* provider/model switch no longer needs a wipe (only this one-time schema bump does).
+
 ---
 
 ## File Layout

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -11,7 +11,7 @@ import (
 )
 
 // SchemaVersion is the schema the binary expects. Bump on any DDL change.
-const SchemaVersion = "2"
+const SchemaVersion = "3"
 
 //go:embed schema.sql
 var schemaSQL string
@@ -67,29 +67,37 @@ func InsertChunk(d *sql.DB, c internal.Chunk) (id int64, inserted bool, err erro
 	return id, true, nil
 }
 
-// InsertEmbedding stores the float32 BLOB for a chunk (idempotent).
-func InsertEmbedding(d *sql.DB, chunkID int64, vector []byte) error {
+// InsertEmbedding stores the float32 BLOB for a chunk (idempotent). model is
+// the "<provider>:<model>" tag identifying what produced vector — see
+// ChunksNeedingEmbedding and internal/search's per-model filtering, which
+// depend on this tag to keep vectors from different providers/models from
+// being silently compared against each other.
+func InsertEmbedding(d *sql.DB, chunkID int64, vector []byte, model string) error {
 	_, err := d.Exec(
-		`INSERT OR REPLACE INTO embeddings(chunk_id, vector) VALUES (?, ?)`,
-		chunkID, vector)
+		`INSERT OR REPLACE INTO embeddings(chunk_id, vector, model) VALUES (?, ?, ?)`,
+		chunkID, vector, model)
 	if err != nil {
 		return fmt.Errorf("insert embedding: %w", err)
 	}
 	return nil
 }
 
-// PendingChunk is a chunk lacking an embedding.
+// PendingChunk is a chunk lacking an embedding, or one embedded by a
+// different model than currentModel.
 type PendingChunk struct {
 	ID      int64
 	Content string
 }
 
-// ChunksWithoutEmbeddings lists chunks with no embeddings row.
-func ChunksWithoutEmbeddings(d *sql.DB) ([]PendingChunk, error) {
+// ChunksNeedingEmbedding lists chunks with no embeddings row, or whose
+// existing embedding's model tag differs from currentModel — the latter
+// case lets a provider/model switch re-embed the affected rows in place
+// via InsertEmbedding's INSERT OR REPLACE, instead of requiring a DB wipe.
+func ChunksNeedingEmbedding(d *sql.DB, currentModel string) ([]PendingChunk, error) {
 	rows, err := d.Query(
 		`SELECT c.id, c.content FROM chunks c
 		 LEFT JOIN embeddings e ON e.chunk_id = c.id
-		 WHERE e.chunk_id IS NULL`)
+		 WHERE e.chunk_id IS NULL OR e.model != ?`, currentModel)
 	if err != nil {
 		return nil, fmt.Errorf("query pending: %w", err)
 	}
@@ -101,6 +109,32 @@ func ChunksWithoutEmbeddings(d *sql.DB) ([]PendingChunk, error) {
 			return nil, err
 		}
 		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// ModelCount is one distinct embedding model tag and how many rows have it.
+type ModelCount struct {
+	Model string
+	Count int
+}
+
+// EmbeddingModels reports the distinct model tags present in embeddings and
+// their row counts — used to warn when a search would exclude rows embedded
+// by a model other than the currently configured one.
+func EmbeddingModels(d *sql.DB) ([]ModelCount, error) {
+	rows, err := d.Query(`SELECT model, COUNT(*) FROM embeddings GROUP BY model`)
+	if err != nil {
+		return nil, fmt.Errorf("query embedding models: %w", err)
+	}
+	defer rows.Close()
+	var out []ModelCount
+	for rows.Next() {
+		var mc ModelCount
+		if err := rows.Scan(&mc.Model, &mc.Count); err != nil {
+			return nil, err
+		}
+		out = append(out, mc)
 	}
 	return out, rows.Err()
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -72,12 +72,12 @@ func TestOpenVersionMismatch(t *testing.T) {
 	}
 }
 
-func TestChunksWithoutEmbeddingsEmptyDB(t *testing.T) {
+func TestChunksNeedingEmbeddingEmptyDB(t *testing.T) {
 	d, _ := Open(tempDB(t))
 	defer d.Close()
-	pending, err := ChunksWithoutEmbeddings(d)
+	pending, err := ChunksNeedingEmbedding(d, "ollama:bge-m3:latest")
 	if err != nil {
-		t.Fatalf("ChunksWithoutEmbeddings on empty DB: %v", err)
+		t.Fatalf("ChunksNeedingEmbedding on empty DB: %v", err)
 	}
 	if len(pending) != 0 {
 		t.Fatalf("empty DB has %d pending chunks, want 0", len(pending))
@@ -91,10 +91,10 @@ func TestInsertEmbeddingReplacement(t *testing.T) {
 	c := internal.Chunk{SessionID: "s1", SessionDate: "2026-06-25", Role: "user",
 		MessageIndex: 0, ChunkIndex: 0, Content: "test chunk content here", CreatedAt: "2026-06-25T10:00:00Z"}
 	id, _, _ := InsertChunk(d, c)
-	if err := InsertEmbedding(d, id, []byte{1, 0, 0, 0}); err != nil {
+	if err := InsertEmbedding(d, id, []byte{1, 0, 0, 0}, "ollama:bge-m3:latest"); err != nil {
 		t.Fatalf("first insert: %v", err)
 	}
-	if err := InsertEmbedding(d, id, []byte{2, 0, 0, 0}); err != nil {
+	if err := InsertEmbedding(d, id, []byte{2, 0, 0, 0}, "ollama:bge-m3:latest"); err != nil {
 		t.Fatalf("second insert (replace): %v", err)
 	}
 	var count int
@@ -115,16 +115,70 @@ func TestInsertEmbeddingAndPendingList(t *testing.T) {
 	c := internal.Chunk{SessionID: "s1", SessionDate: "2026-06-25", Role: "user",
 		MessageIndex: 0, ChunkIndex: 0, Content: "needs an embedding here", CreatedAt: "2026-06-25T10:00:00Z"}
 	id, _, _ := InsertChunk(d, c)
-	pending, err := ChunksWithoutEmbeddings(d)
+	pending, err := ChunksNeedingEmbedding(d, "ollama:bge-m3:latest")
 	if err != nil || len(pending) != 1 {
 		t.Fatalf("pending before = %d err=%v, want 1", len(pending), err)
 	}
-	if err := InsertEmbedding(d, id, []byte{1, 2, 3, 4}); err != nil {
+	if err := InsertEmbedding(d, id, []byte{1, 2, 3, 4}, "ollama:bge-m3:latest"); err != nil {
 		t.Fatalf("InsertEmbedding: %v", err)
 	}
-	pending, _ = ChunksWithoutEmbeddings(d)
+	pending, _ = ChunksNeedingEmbedding(d, "ollama:bge-m3:latest")
 	if len(pending) != 0 {
 		t.Fatalf("pending after = %d, want 0", len(pending))
+	}
+}
+
+func TestChunksNeedingEmbeddingIncludesForeignModel(t *testing.T) {
+	// A chunk embedded under a different model tag than currentModel must
+	// come back as pending — this is what lets a provider/model switch
+	// re-embed in place instead of requiring a DB wipe.
+	d, _ := Open(tempDB(t))
+	defer d.Close()
+	c := internal.Chunk{SessionID: "s1", SessionDate: "2026-06-25", Role: "user",
+		MessageIndex: 0, ChunkIndex: 0, Content: "embedded under an old model", CreatedAt: "2026-06-25T10:00:00Z"}
+	id, _, _ := InsertChunk(d, c)
+	if err := InsertEmbedding(d, id, []byte{1, 2, 3, 4}, "ollama:bge-m3:latest"); err != nil {
+		t.Fatalf("InsertEmbedding: %v", err)
+	}
+	pending, err := ChunksNeedingEmbedding(d, "openrouter:some-model")
+	if err != nil {
+		t.Fatalf("ChunksNeedingEmbedding: %v", err)
+	}
+	if len(pending) != 1 || pending[0].ID != id {
+		t.Fatalf("pending = %+v, want the foreign-model chunk %d", pending, id)
+	}
+	// Same-model chunk must NOT come back as pending.
+	pending, _ = ChunksNeedingEmbedding(d, "ollama:bge-m3:latest")
+	if len(pending) != 0 {
+		t.Fatalf("pending for matching model = %d, want 0", len(pending))
+	}
+}
+
+func TestEmbeddingModels(t *testing.T) {
+	d, _ := Open(tempDB(t))
+	defer d.Close()
+	c1 := internal.Chunk{SessionID: "s1", SessionDate: "2026-06-25", Role: "user",
+		MessageIndex: 0, ChunkIndex: 0, Content: "first chunk content here", CreatedAt: "2026-06-25T10:00:00Z"}
+	c2 := internal.Chunk{SessionID: "s1", SessionDate: "2026-06-25", Role: "user",
+		MessageIndex: 1, ChunkIndex: 0, Content: "second chunk content here", CreatedAt: "2026-06-25T10:00:00Z"}
+	id1, _, _ := InsertChunk(d, c1)
+	id2, _, _ := InsertChunk(d, c2)
+	if err := InsertEmbedding(d, id1, []byte{1, 2, 3, 4}, "ollama:bge-m3:latest"); err != nil {
+		t.Fatalf("InsertEmbedding 1: %v", err)
+	}
+	if err := InsertEmbedding(d, id2, []byte{5, 6, 7, 8}, "openrouter:some-model"); err != nil {
+		t.Fatalf("InsertEmbedding 2: %v", err)
+	}
+	models, err := EmbeddingModels(d)
+	if err != nil {
+		t.Fatalf("EmbeddingModels: %v", err)
+	}
+	counts := map[string]int{}
+	for _, mc := range models {
+		counts[mc.Model] = mc.Count
+	}
+	if counts["ollama:bge-m3:latest"] != 1 || counts["openrouter:some-model"] != 1 {
+		t.Fatalf("counts = %+v, want 1 each for the two distinct models", counts)
 	}
 }
 

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -2,7 +2,7 @@ CREATE TABLE meta (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
-INSERT INTO meta(key, value) VALUES ('schema_version', '2');
+INSERT INTO meta(key, value) VALUES ('schema_version', '3');
 
 CREATE TABLE chunks (
     id            INTEGER PRIMARY KEY,
@@ -31,7 +31,8 @@ END;
 
 CREATE TABLE embeddings (
     chunk_id  INTEGER PRIMARY KEY REFERENCES chunks(id) ON DELETE CASCADE,
-    vector    BLOB    NOT NULL
+    vector    BLOB    NOT NULL,
+    model     TEXT    NOT NULL
 );
 
 CREATE UNIQUE INDEX idx_chunks_dedup

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -109,6 +109,23 @@ func (c *Client) Embed(ctx context.Context, text string) ([]float32, error) {
 	return out.Embeddings[0], nil
 }
 
+// ModelTag identifies which provider/model produced an Embedder's vectors,
+// as "<provider>:<model>" (e.g. "ollama:bge-m3:latest"). Stored per-row in
+// the embeddings table so search can filter to the currently configured
+// model and warn about rows from a different one, instead of silently
+// scoring mismatched-dimension vectors as 0. A package-level type switch,
+// not an Embedder interface method — widening the interface would break
+// the stubEmbedder test doubles in internal/search and internal/mine.
+// Unrecognized Embedder implementations tag as "unknown".
+func ModelTag(e Embedder) string {
+	switch c := e.(type) {
+	case *Client:
+		return "ollama:" + c.model
+	default:
+		return "unknown"
+	}
+}
+
 // EncodeVector serializes floats as little-endian float32 bytes.
 func EncodeVector(v []float32) []byte {
 	buf := make([]byte, 4*len(v))

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -116,13 +116,20 @@ func (c *Client) Embed(ctx context.Context, text string) ([]float32, error) {
 // scoring mismatched-dimension vectors as 0. A package-level type switch,
 // not an Embedder interface method — widening the interface would break
 // the stubEmbedder test doubles in internal/search and internal/mine.
-// Unrecognized Embedder implementations tag as "unknown".
+//
+// An unrecognized implementation tags as "unknown:<Go type>" (via %T), not
+// a shared literal "unknown" — two different unrecognized Embedders (e.g.
+// two distinct test doubles, or a future provider added without a case
+// here) must never collide under the same tag, or ChunksNeedingEmbedding
+// and cosineSearch would treat their — potentially incompatible-dimension
+// — vectors as interchangeable, the exact class of bug this tag exists to
+// prevent.
 func ModelTag(e Embedder) string {
 	switch c := e.(type) {
 	case *Client:
 		return "ollama:" + c.model
 	default:
-		return "unknown"
+		return fmt.Sprintf("unknown:%T", e)
 	}
 }
 

--- a/internal/mine/mine.go
+++ b/internal/mine/mine.go
@@ -70,6 +70,7 @@ func Run(ctx context.Context, dbPath, jsonlPath string, emb embed.Embedder) (Res
 
 	// Phase 2: embed new chunks, respecting the ctx deadline. Once ctx is done,
 	// remaining chunks are deferred (not embedded) — never abort the mine.
+	modelTag := embed.ModelTag(emb)
 	for _, p := range pending {
 		if ctx.Err() != nil {
 			res.Deferred++
@@ -80,7 +81,7 @@ func Run(ctx context.Context, dbPath, jsonlPath string, emb embed.Embedder) (Res
 			res.Skipped++
 			continue
 		}
-		if err := db.InsertEmbedding(d, p.id, embed.EncodeVector(vec)); err != nil {
+		if err := db.InsertEmbedding(d, p.id, embed.EncodeVector(vec), modelTag); err != nil {
 			res.Skipped++
 		} else {
 			res.Embedded++

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/valpere/session-indexer/internal"
+	"github.com/valpere/session-indexer/internal/db"
 	"github.com/valpere/session-indexer/internal/embed"
 )
 
@@ -40,7 +41,13 @@ func cosineSearch(d *sql.DB, emb embed.Embedder, query string, limit int) ([]int
 	if err != nil {
 		return nil, fmt.Errorf("embed query: %w", err)
 	}
-	rows, err := d.Query(`SELECT chunk_id, vector FROM embeddings`)
+	// Filtered to the currently configured model's rows only — mixing
+	// vectors from a different provider/model would compare incompatible
+	// dimensions. cosine() already zero-scores a length mismatch rather
+	// than erroring, so an unfiltered scan would silently sort those rows
+	// to the bottom instead of excluding them with a visible warning (see
+	// main.go's post-Search EmbeddingModels check).
+	rows, err := d.Query(`SELECT chunk_id, vector FROM embeddings WHERE model = ?`, embed.ModelTag(emb))
 	if err != nil {
 		return nil, fmt.Errorf("load embeddings: %w", err)
 	}
@@ -137,15 +144,16 @@ func cosine(a, b []float32) float64 {
 
 // Stats describes index state for the stats subcommand.
 type Stats struct {
-	Sessions       int
-	Chunks         int
-	Embedded       int
-	Pending        int
-	Facts          int // currently valid (non-tombstoned) facts
-	PendingDistill int // chunks not yet through distill
-	Oldest         string
-	Newest         string
-	DBSize         string // human-readable on-disk size, e.g. "4.2 MB"
+	Sessions        int
+	Chunks          int
+	Embedded        int
+	Pending         int
+	EmbeddingModels []db.ModelCount // distinct model tags present, for spotting a provider/model mismatch
+	Facts           int             // currently valid (non-tombstoned) facts
+	PendingDistill  int             // chunks not yet through distill
+	Oldest          string
+	Newest          string
+	DBSize          string // human-readable on-disk size, e.g. "4.2 MB"
 }
 
 // GetStats reports index counts, date range, and on-disk DB size. dbPath is
@@ -163,6 +171,9 @@ func GetStats(d *sql.DB, dbPath string) (Stats, error) {
 		return s, err
 	}
 	s.Pending = s.Chunks - s.Embedded
+	if models, err := db.EmbeddingModels(d); err == nil {
+		s.EmbeddingModels = models
+	}
 	if err := q(`SELECT COUNT(*) FROM facts WHERE until IS NULL`, &s.Facts); err != nil {
 		return s, err
 	}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -38,11 +38,12 @@ func seed(t *testing.T, emb embed.Embedder) string {
 		{"ring buffer for the event queue avoids allocations", []float32{0, 0, 1}},
 		{"json schema config validation approach", []float32{1, 0, 0}},
 	}
+	modelTag := embed.ModelTag(emb)
 	for i, r := range rows {
 		c := internal.Chunk{SessionID: "s1", SessionDate: "2026-06-25", Role: "user",
 			MessageIndex: i, ChunkIndex: 0, Content: r.content, CreatedAt: "2026-06-25T10:00:00Z"}
 		id, _, _ := db.InsertChunk(d, c)
-		db.InsertEmbedding(d, id, embed.EncodeVector(r.vec))
+		db.InsertEmbedding(d, id, embed.EncodeVector(r.vec), modelTag)
 	}
 	return dbp
 }
@@ -157,6 +158,44 @@ func TestCosineMismatchedLength(t *testing.T) {
 func TestCosineEmptyVectors(t *testing.T) {
 	if got := cosine(nil, nil); got != 0 {
 		t.Fatalf("cosine(nil, nil) = %v, want 0", got)
+	}
+}
+
+// TestSearchExcludesForeignModelRows: a row embedded under a different
+// model tag than the querying Embedder's must be excluded from cosine
+// results entirely, not scored 0 and sorted last — cosine() can't tell the
+// difference between "genuinely dissimilar" and "wrong dimensionality",
+// so cosineSearch filters by model tag before scoring at all.
+func TestSearchExcludesForeignModelRows(t *testing.T) {
+	emb := stubEmbedder{avail: true}
+	dbp := seed(t, emb) // both seeded rows tagged with ModelTag(emb) = "unknown"
+	d, _ := db.Open(dbp)
+	defer d.Close()
+
+	// A third chunk, embedded under a different model tag, should never
+	// appear in results for this embedder even though its vector would
+	// otherwise be the closest match.
+	c := internal.Chunk{SessionID: "s1", SessionDate: "2026-06-25", Role: "user",
+		MessageIndex: 2, ChunkIndex: 0, Content: "foreign model row, closest vector, must be excluded", CreatedAt: "2026-06-25T10:00:00Z"}
+	id, _, err := db.InsertChunk(d, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.InsertEmbedding(d, id, embed.EncodeVector([]float32{0, 0, 1}), "some-other-model"); err != nil {
+		t.Fatal(err)
+	}
+
+	res, used, err := Search(d, emb, "queue buffering", 5)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !used {
+		t.Fatal("usedEmbeddings = false, want true")
+	}
+	for _, r := range res {
+		if r.Content == c.Content {
+			t.Fatalf("foreign-model row appeared in results: %+v", res)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Prerequisite for supporting OpenRouter as a second embedding provider alongside Ollama (full plan: 3 PRs, this is #1 of 3, Ollama-only).

- `embeddings.model` column tags each row `"<provider>:<model>"` via `embed.ModelTag`. Fixes a real silent-corruption hazard: switching the embedding model previously left old rows with mismatched vector dimensions, and `cosine()` zero-scores a length mismatch rather than erroring — those rows just vanished from search results with no error, no warning, nothing in `stats`.
- `SchemaVersion` `"2"` → `"3"` — existing DBs need a one-time delete-and-re-mine, per this project's documented no-migration-framework policy (same as the 2026-07-18 facts-layer bump).
- `ChunksNeedingEmbedding` replaces `ChunksWithoutEmbeddings` — matches rows with no embedding OR a stale model tag, so `session-indexer embed` re-embeds foreign-model rows in place. This means *future* model/provider switches never need a wipe again (only this one-time bump does).
- `cosineSearch` filters to the current model's rows; `search` warns (doesn't silently exclude) when other-model rows exist. `stats` prints a line per distinct embedding model.
- `embed.ModelTag(Embedder)` is a package-level type switch, not an interface method — `stubEmbedder` test doubles in `internal/mine`/`internal/search` are unchanged.

## Test plan
- [x] `go build ./... && go vet ./... && gofmt -l . && go test -race ./...` — 82 tests pass (3 new)
- [x] End-to-end manual verification (not just unit tests): mined a real session against a live Ollama, manually retagged a row to simulate a stale model, confirmed `embed` re-embeds it in place, confirmed `search` and `stats` both surface the mismatch correctly beforehand

🤖 Generated with [Claude Code](https://claude.com/claude-code)