### PR TITLE
chore: ignore sbin/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ vendor/
 docs/superpowers/
 
 tmp/
+sbin/


### PR DESCRIPTION
## Summary
Add `sbin/` to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)