### PR TITLE
docs(readme): add Product Hunt launch badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # session-indexer
 
 [![CI](https://github.com/valpere/session-indexer/actions/workflows/ci.yml/badge.svg)](https://github.com/valpere/session-indexer/actions/workflows/ci.yml)
+[![session-indexer - Semantic search over your own Claude Code session history | Product Hunt](https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1230655&theme=light)](https://www.producthunt.com/products/session-indexer)
 
 Per-project semantic search over Claude Code session history. Indexes JSONL
 transcripts into a per-project SQLite store; retrieves via bge-m3 embeddings


### PR DESCRIPTION
## Summary
- Adds the official Product Hunt "featured" badge (post_id=1230655) to the top of README.md, linking to the live launch page (https://www.producthunt.com/products/session-indexer).
- Timed for launch day (2026-08-25) — PH's own launch tips recommend an embed to drive support during the first-day voting window.

## Test plan
- [x] Verified `post_id=1230655` and badge SVG URL against the real, currently-live PH embed page for this product (not guessed).
- [x] Docs-only change, no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)