### PR TITLE
chore(ci): file an issue on scheduled vulncheck failure

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,9 +42,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh label create automated-vulncheck-failure \
+          gh label create automated-vulncheck-failure --repo "${{ github.repository }}" --force \
             --description "Filed automatically by the scheduled govulncheck job" \
-            --color d73a4a 2>/dev/null || true
+            --color d73a4a
 
           open_count=$(gh issue list --repo "${{ github.repository }}" \
             --label automated-vulncheck-failure --state open \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -50,7 +50,7 @@ jobs:
             --label automated-vulncheck-failure --state open \
             --json number --jq 'length') || open_count=0
 
-          if [ "$open_count" -eq 0 ]; then
+          if [ "${open_count:-0}" -eq 0 ]; then
             run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             gh issue create --repo "${{ github.repository }}" \
               --title "Scheduled govulncheck failed on $(date -u +%Y-%m-%d)" \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v7
 
@@ -30,3 +31,29 @@ jobs:
 
       - name: Run govulncheck
         run: govulncheck ./...
+
+      - name: File issue on scheduled failure
+        # Only for the `schedule` trigger: push/pull_request failures already
+        # surface via normal PR/branch-protection checks, but nobody actively
+        # watches a scheduled run the way they watch their own PR. Dedup via
+        # the automated-vulncheck-failure label so a persistently broken
+        # check files one issue, not one per week.
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create automated-vulncheck-failure \
+            --description "Filed automatically by the scheduled govulncheck job" \
+            --color d73a4a 2>/dev/null || true
+
+          open_count=$(gh issue list --repo "${{ github.repository }}" \
+            --label automated-vulncheck-failure --state open \
+            --json number --jq 'length')
+
+          if [ "$open_count" -eq 0 ]; then
+            run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            gh issue create --repo "${{ github.repository }}" \
+              --title "Scheduled govulncheck failed on $(date -u +%Y-%m-%d)" \
+              --label automated-vulncheck-failure \
+              --body "The weekly scheduled \`govulncheck\` run failed: ${run_url}"
+          fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,7 +48,7 @@ jobs:
 
           open_count=$(gh issue list --repo "${{ github.repository }}" \
             --label automated-vulncheck-failure --state open \
-            --json number --jq 'length')
+            --json number --jq 'length') || open_count=0
 
           if [ "$open_count" -eq 0 ]; then
             run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Summary

- A scheduled `vulncheck` run failing red relies on someone actively checking the Actions tab, unlike a PR run whose checks the author is already watching. Adds a final step to the `vulncheck` job that files a deduped GitHub issue when the `schedule`-triggered run fails, on top of GitHub's own built-in scheduled-workflow-failure notification (which already exists but depends entirely on personal notification settings with no repo-visible fallback).
- The step only fires `if: failure() && github.event_name == 'schedule'` — push/pull_request failures already surface via normal PR/branch-protection checks and are explicitly excluded.
- Dedup via an `automated-vulncheck-failure` label: checks `gh issue list --label ... --state open` first and only creates a new issue if none is open, so a persistently broken check files one issue, not one per week. The issue body links the failed run.
- No new marketplace action — plain `run:` step using the `gh` CLI (already on GitHub-hosted runners), matching this repo's existing minimal-third-party-action style.
- `.github/workflows/*.yml`-only change; no Go source touched.

## Review notes

- static-analysis flagged that `open_count=$(gh issue list ...)` had no error handling if the `gh` call itself errored — fixed with `|| open_count=0`.
- tech-lead review (APPROVED WITH CHANGES) caught a second gap in the same spot: if `gh` exits 0 with empty stdout, `open_count` stayed unset and `[ "$open_count" -eq 0 ]` threw a shell error, evaluated false, and silently skipped filing the issue — the opposite of what this step exists to prevent. Fixed with `${open_count:-0}` so both failure modes bias toward notifying rather than silently skipping.
- tech-lead also recommended (non-blocking, since the single-job shape was the pre-approved plan) splitting the notifier into its own job so `issues: write` doesn't sit on the job's token during ordinary push/PR runs. Filed as follow-up #59 rather than expanding this PR's scope.
- Docs: checked CLAUDE.md and docs/architecture.md for existing prose describing `security.yml`'s trigger/step mechanics — none exists (PR #54, which added the schedule trigger itself, didn't add any either), so no doc section was added here, matching that precedent and the issue's own instruction not to force a new section for a small CI addition.

## Test plan

- [x] `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/security.yml'))"` — YAML well-formed
- [x] `go vet ./...` — clean
- [x] `go test -race ./...` — 82 passing in 8 packages, unaffected (no Go files touched)
- [x] static-analysis review — WARNINGS_ONLY, addressed
- [x] tech-lead review — APPROVED WITH CHANGES, required fix applied

Closes https://github.com/valpere/session-indexer/issues/55