### PR TITLE
chore(ci): scope issues:write permission away from push/PR vulncheck runs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
     steps:
       - uses: actions/checkout@v7
 
@@ -32,13 +31,21 @@ jobs:
       - name: Run govulncheck
         run: govulncheck ./...
 
+  notify-failure:
+    needs: vulncheck
+    # Only for the `schedule` trigger: push/pull_request failures already
+    # surface via normal PR/branch-protection checks, but nobody actively
+    # watches a scheduled run the way they watch their own PR. Dedup via
+    # the automated-vulncheck-failure label so a persistently broken
+    # check files one issue, not one per week. Split into its own job (not
+    # a step in vulncheck) so `issues: write` is only ever granted here,
+    # never on push/pull_request runs of vulncheck.
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
       - name: File issue on scheduled failure
-        # Only for the `schedule` trigger: push/pull_request failures already
-        # surface via normal PR/branch-protection checks, but nobody actively
-        # watches a scheduled run the way they watch their own PR. Dedup via
-        # the automated-vulncheck-failure label so a persistently broken
-        # check files one issue, not one per week.
-        if: failure() && github.event_name == 'schedule'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

- Splits the scheduled-failure notifier out of the `vulncheck` job into a new `notify-failure` job (`needs: vulncheck`, `if: failure() && github.event_name == 'schedule'`) that carries `issues: write`.
- Reverts `vulncheck`'s `permissions:` block to `contents: read` only, so push/PR runs no longer carry a writable `GITHUB_TOKEN` they never use.
- Step body (label create with `--force`, dedup check, issue create) moved verbatim — no logic changes. `notify-failure` needs no checkout; `gh --repo` works outside a git work tree.
- Does not touch the unpinned `go install golang.org/x/vuln/cmd/govulncheck@latest` line — that's tracked separately in #61.

Closes #59

## Test plan

- [x] `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/security.yml'))"` — YAML valid
- [x] `go vet ./...` — passes
- [x] `go test -race ./...` — 82 tests pass, 8 packages (unaffected, as expected for a workflow-only change)
- [x] static-analysis review: CLEAN, no issues found
- [x] tech-lead post-implementation review: APPROVED — verified `failure()`/`needs:` semantics, confirmed step body byte-identical, confirmed `govulncheck@latest` line untouched, confirmed blast-radius reduction