### PR TITLE
feat: browse the index without a query (sessions/list/show/facts list)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,10 @@ session-indexer search  <query>      --db <path> [--limit N] [--json]
 session-indexer embed                --db <path>        # backfill missing embeddings
 session-indexer stats                --db <path>        # sessions, chunks, facts, pending, DB size
 session-indexer distill              --db <path> [--threshold 0.7]   # LLM-extract facts, manual, no deadline
-session-indexer facts search/get/related/supersede --db <path>       # query the facts layer
+session-indexer facts search/list/get/related/supersede --db <path>  # query the facts layer
+session-indexer sessions             --db <path> [--by-session]      # roll up by day (default) or session_id
+session-indexer list                 --db <path> [--limit N] [--since D] [--until D] [--role R] [--session ID]
+session-indexer show    <chunk-id>   --db <path>        # full chunk text + facts distilled from it
 ```
 
 ### File Layout
@@ -53,7 +56,9 @@ internal/search/
 internal/distill/
   distill.go                      — Ollama generate client + orchestration: confidence gate (deterministic Go check, not LLM-enforced), automatic supersession with a validated-against-context safeguard
 internal/facts/
-  facts.go                        — read verbs: Search (FTS5 BM25), Get (supersedes edges), Related (depth-1)
+  facts.go                        — read verbs: Search (FTS5 BM25), List (no query, browse), Get (supersedes edges), Related (depth-1), BySourceChunk (provenance for `show`)
+internal/browse/
+  browse.go                       — read-only enumeration without a query: ListChunks, GetChunk, Days, Sessions — backs `list`/`show`/`sessions`
 ```
 
 ### Storage
@@ -79,6 +84,30 @@ Ollama REST: `POST localhost:11434/api/embed`, model `bge-m3:latest` (1024 dims)
 ### Search
 
 Primary: embed query → exhaustive cosine over all `embeddings` rows loaded into memory. Scale assumption: <10k chunks. Fallback to FTS5 BM25 when Ollama is unavailable **OR** the store has zero embeddings (e.g. mined while Ollama was down); FTS uses per-term OR recall, not phrase match. Output notes when the fallback is used.
+
+### Browsing
+
+`internal/browse` provides read-only enumeration without a query — `sessions`,
+`list`, `show` — deliberately separate from `internal/search`, whose package
+doc scopes it to *ranked* retrieval. `show <chunk-id>` composes
+`browse.GetChunk` with `facts.BySourceChunk` to close the provenance loop from
+a fact (`facts get <id>` reports `source_chunk_id`) back to the actual chunk
+text it was distilled from — the highest-value part of this layer, since
+`stats` only gives aggregates and `search`/`facts search` both require a
+query term.
+
+`sessions` defaults to grouping by `session_date`, not `session_id`:
+`--resume` keeps a single `sessionId` alive for months, so `session_id` in
+practice produces a few huge buckets and many single-chunk ones, while
+`session_date` gives evenly-sized buckets that match how people recall work.
+`--by-session` gives the raw `session_id` rollup when that skew itself is
+what you want to see.
+
+No index exists on `session_date` — measured on a live 26k-chunk/150MB store,
+`ORDER BY session_date DESC LIMIT N` full-scans in single-digit milliseconds,
+and adding an index would force another schema bump (and the re-mine that
+comes with it) for no measurable gain. Revisit only if a future schema bump
+happens anyway.
 
 ### Facts Layer
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ session-indexer facts search   <query>            --db .claude/sessions.db [--li
 session-indexer facts get      <id>               --db .claude/sessions.db [--json]
 session-indexer facts related  <id>               --db .claude/sessions.db [--json]
 session-indexer facts supersede <new-id> <old-id> --db .claude/sessions.db
+
+# Browse without a query
+session-indexer sessions             --db .claude/sessions.db [--by-session] [--json]
+session-indexer list                 --db .claude/sessions.db [--limit N] [--since D] [--until D] [--role R] [--session ID] [--json]
+session-indexer show <chunk-id>      --db .claude/sessions.db [--json]
+session-indexer facts list           --db .claude/sessions.db [--limit N] [--since D] [--until D] [--min-confidence F] [--include-expired] [--json]
 ```
 
 ### `mine` output
@@ -151,6 +157,44 @@ session-indexer facts related 7 --db .claude/sessions.db
 # Manual override (audit/backstop — distill already judges supersession automatically)
 session-indexer facts supersede 9 7 --db .claude/sessions.db
 ```
+
+## Browsing without a query
+
+`search` and `facts search` both need a query term; `stats` gives aggregates
+only. `sessions`, `list`, `show`, and `facts list` fill the gap — enumerate
+what's actually in the store, and close the provenance loop from a fact back
+to the text it was distilled from:
+
+```bash
+# What's in the store, by day (the default — see why below)
+session-indexer sessions --db .claude/sessions.db
+# → 2026-08-25    43 chunks  (43 embedded, 12 distilled, 2 sessions)
+#   2026-08-24   156 chunks  (156 embedded, 89 distilled, 1 sessions)
+
+# Raw session_id rollup instead — usually far more skewed, see below
+session-indexer sessions --db .claude/sessions.db --by-session
+
+# Recent chunks, newest first, with filters
+session-indexer list --db .claude/sessions.db --limit 5 --since 2026-08-20 --role assistant
+
+# Close the provenance loop: a fact's source_chunk_id, then the chunk itself
+session-indexer facts get 7 --db .claude/sessions.db
+# → source_chunk_id: 135
+session-indexer show 135 --db .claude/sessions.db
+# → full chunk text, plus every fact distilled from it (including 7)
+
+# Facts without a query term
+session-indexer facts list --db .claude/sessions.db --limit 10 --min-confidence 0.9
+```
+
+`sessions` defaults to grouping by `session_date`, not `session_id`. In
+practice `session_id` is a poor browse axis: `--resume` keeps the same
+`sessionId` alive for months, so a handful of ids end up owning most chunks
+while the rest own a handful each — `--by-session` shows this raw view when
+you want it, but `session_date` gives evenly-sized, recall-shaped buckets by
+default. No index exists on `session_date`; a full scan is single-digit
+milliseconds even on a store with tens of thousands of chunks, so adding one
+isn't worth another schema bump.
 
 ## Embeddings
 

--- a/cmd/session-indexer/main.go
+++ b/cmd/session-indexer/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/valpere/session-indexer/internal"
+	"github.com/valpere/session-indexer/internal/browse"
 	"github.com/valpere/session-indexer/internal/db"
 	"github.com/valpere/session-indexer/internal/distill"
 	"github.com/valpere/session-indexer/internal/embed"
@@ -162,6 +163,102 @@ func main() {
 		},
 	}
 
+	var listLimit int
+	var listSince, listUntil, listRole, listSession string
+	var listJSON bool
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List chunks without a query, newest first",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if dbPath == "" {
+				return fmt.Errorf("--db is required")
+			}
+			d, err := db.Open(dbPath)
+			if err != nil {
+				return err
+			}
+			defer d.Close()
+			res, err := browse.ListChunks(d, browse.ListOpts{
+				Limit: listLimit, Since: listSince, Until: listUntil,
+				Role: listRole, Session: listSession,
+			})
+			if err != nil {
+				return err
+			}
+			return printChunks(res, listJSON)
+		},
+	}
+	listCmd.Flags().IntVar(&listLimit, "limit", 20, "max chunks")
+	listCmd.Flags().StringVar(&listSince, "since", "", "only chunks on/after this date (YYYY-MM-DD)")
+	listCmd.Flags().StringVar(&listUntil, "until", "", "only chunks on/before this date (YYYY-MM-DD)")
+	listCmd.Flags().StringVar(&listRole, "role", "", "filter by role: user or assistant")
+	listCmd.Flags().StringVar(&listSession, "session", "", "filter by exact session_id")
+	listCmd.Flags().BoolVar(&listJSON, "json", false, "machine-readable output")
+
+	var showJSON bool
+	showCmd := &cobra.Command{
+		Use:   "show <chunk-id>",
+		Short: "Show one chunk's full content and the facts distilled from it",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if dbPath == "" {
+				return fmt.Errorf("--db is required")
+			}
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid chunk id %q: %w", args[0], err)
+			}
+			d, err := db.Open(dbPath)
+			if err != nil {
+				return err
+			}
+			defer d.Close()
+			chunk, err := browse.GetChunk(d, id)
+			if err != nil {
+				return err
+			}
+			chunkFacts, err := facts.BySourceChunk(d, id)
+			if err != nil {
+				return err
+			}
+			return printChunkDetail(chunk, chunkFacts, showJSON)
+		},
+	}
+	showCmd.Flags().BoolVar(&showJSON, "json", false, "machine-readable output")
+
+	var bySession bool
+	var sessionsJSON bool
+	sessionsCmd := &cobra.Command{
+		Use:   "sessions",
+		Short: "Roll up indexed chunks by day (or by session_id with --by-session)",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if dbPath == "" {
+				return fmt.Errorf("--db is required")
+			}
+			d, err := db.Open(dbPath)
+			if err != nil {
+				return err
+			}
+			defer d.Close()
+			if bySession {
+				res, err := browse.Sessions(d)
+				if err != nil {
+					return err
+				}
+				return printSessions(res, sessionsJSON)
+			}
+			res, err := browse.Days(d)
+			if err != nil {
+				return err
+			}
+			return printDays(res, sessionsJSON)
+		},
+	}
+	sessionsCmd.Flags().BoolVar(&bySession, "by-session", false, "group by raw session_id instead of day (skewed — see README)")
+	sessionsCmd.Flags().BoolVar(&sessionsJSON, "json", false, "machine-readable output")
+
 	var threshold float64
 	var distillModel string
 	var distillConcurrency int
@@ -306,10 +403,45 @@ func main() {
 		},
 	}
 
-	factsCmd := &cobra.Command{Use: "facts", Short: "Query the distilled facts layer"}
-	factsCmd.AddCommand(factsSearchCmd, factsGetCmd, factsRelatedCmd, factsSupersedeCmd)
+	var factsListLimit int
+	var factsListSince, factsListUntil string
+	var factsListMinConfidence float64
+	var factsListIncludeExpired bool
+	var factsListJSON bool
+	factsListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List facts without a query, newest first",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if dbPath == "" {
+				return fmt.Errorf("--db is required")
+			}
+			d, err := db.Open(dbPath)
+			if err != nil {
+				return err
+			}
+			defer d.Close()
+			res, err := facts.List(d, facts.ListOpts{
+				Limit: factsListLimit, Since: factsListSince, Until: factsListUntil,
+				MinConfidence: factsListMinConfidence, IncludeExpired: factsListIncludeExpired,
+			})
+			if err != nil {
+				return err
+			}
+			return printFacts(res, factsListJSON)
+		},
+	}
+	factsListCmd.Flags().IntVar(&factsListLimit, "limit", 20, "max facts")
+	factsListCmd.Flags().StringVar(&factsListSince, "since", "", "only facts on/after this date (YYYY-MM-DD)")
+	factsListCmd.Flags().StringVar(&factsListUntil, "until", "", "only facts on/before this date (YYYY-MM-DD)")
+	factsListCmd.Flags().Float64Var(&factsListMinConfidence, "min-confidence", 0, "only facts at/above this confidence")
+	factsListCmd.Flags().BoolVar(&factsListIncludeExpired, "include-expired", false, "include tombstoned facts")
+	factsListCmd.Flags().BoolVar(&factsListJSON, "json", false, "machine-readable output")
 
-	root.AddCommand(mineCmd, searchCmd, embedCmd, statsCmd, distillCmd, factsCmd)
+	factsCmd := &cobra.Command{Use: "facts", Short: "Query the distilled facts layer"}
+	factsCmd.AddCommand(factsSearchCmd, factsListCmd, factsGetCmd, factsRelatedCmd, factsSupersedeCmd)
+
+	root.AddCommand(mineCmd, searchCmd, embedCmd, statsCmd, listCmd, showCmd, sessionsCmd, distillCmd, factsCmd)
 	if err := root.Execute(); err != nil {
 		switch {
 		case errors.Is(err, distill.ErrCircuitBreaker):
@@ -454,6 +586,76 @@ func snippet(s string) string {
 		cut = cut[:i]
 	}
 	return cut + "…"
+}
+
+func printChunks(res []internal.ChunkSummary, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(res)
+	}
+	for _, c := range res {
+		fmt.Printf("[%d | %s | %s]\n%s\n%s\n", c.ID, c.SessionDate, c.Role, snippet(c.Content),
+			"──────────────────────────────────────────────────────")
+	}
+	if len(res) == 0 {
+		fmt.Println("(no results)")
+	}
+	return nil
+}
+
+func printChunkDetail(chunk internal.ChunkSummary, chunkFacts []internal.Fact, asJSON bool) error {
+	if asJSON {
+		out := struct {
+			Chunk internal.ChunkSummary `json:"chunk"`
+			Facts []internal.Fact       `json:"facts"`
+		}{chunk, chunkFacts}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	}
+	fmt.Printf("[chunk %d | %s | %s | session %s]\n%s\n", chunk.ID, chunk.SessionDate, chunk.Role,
+		chunk.SessionID, chunk.Content)
+	if len(chunkFacts) > 0 {
+		fmt.Printf("\nFacts distilled from this chunk: %d\n", len(chunkFacts))
+		for _, f := range chunkFacts {
+			fmt.Printf("  [%d] %s | %s | %s (confidence %.2f)%s\n",
+				f.ID, f.Subject, f.Predicate, f.Object, f.Confidence, factStatusSuffix(f))
+		}
+	}
+	return nil
+}
+
+func printDays(res []internal.DaySummary, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(res)
+	}
+	for _, s := range res {
+		fmt.Printf("%s  %5d chunks  (%d embedded, %d distilled, %d sessions)\n",
+			s.SessionDate, s.Chunks, s.Embedded, s.Distilled, s.Sessions)
+	}
+	if len(res) == 0 {
+		fmt.Println("(no results)")
+	}
+	return nil
+}
+
+func printSessions(res []internal.SessionSummary, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(res)
+	}
+	for _, s := range res {
+		fmt.Printf("%s  %5d chunks  %s → %s  (%d embedded, %d distilled)\n",
+			s.SessionID, s.Chunks, s.FirstDate, s.LastDate, s.Embedded, s.Distilled)
+	}
+	if len(res) == 0 {
+		fmt.Println("(no results)")
+	}
+	return nil
 }
 
 func printFacts(res []internal.Fact, asJSON bool) error {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -293,6 +293,54 @@ The config validation approach using JSON Schema has a key advantage...
 
 ---
 
+## Browsing
+
+`internal/browse` provides read-only enumeration with no query term required
+— `sessions`, `list`, `show` — kept out of `internal/search` on purpose,
+since that package's doc scopes it to *ranked* retrieval and its
+`SearchResult` type carries a `Score` that is meaningless when nothing was
+ranked. `internal.ChunkSummary` is the browse-layer row type instead:
+
+```
+ListChunks(d, ListOpts{Limit, Since, Until, Role, Session}) → []ChunkSummary
+GetChunk(d, id)                                            → ChunkSummary
+Days(d)                                                     → []DaySummary    (session_date rollup)
+Sessions(d)                                                 → []SessionSummary (session_id rollup)
+```
+
+`ListChunks` orders `session_date DESC, id DESC` — not `id DESC` alone,
+because re-mining an older JSONL later inserts high-id rows with an old
+`session_date`, and a browse view should sort by when the content happened,
+not when it was indexed.
+
+`sessions` defaults to the `Days` rollup (grouped by `session_date`), not
+`Sessions` (`session_id`). In practice `--resume` keeps one `sessionId` alive
+for months, so grouping by `session_id` produces a few huge buckets and many
+single-chunk ones — `session_date` gives evenly-sized buckets that match how
+people actually recall work ("what was I doing last week"). `--by-session`
+exposes the raw `session_id` rollup for when that skew is itself of
+interest.
+
+No index on `session_date`: `ORDER BY session_date DESC LIMIT N` full-scans
+in single-digit milliseconds even on a live 26k-chunk/150MB store (measured,
+not estimated). Adding one would force another schema bump — and the
+delete-and-re-mine that comes with it — for no measurable gain; revisit only
+if a future bump happens anyway.
+
+`show <chunk-id>` composes `browse.GetChunk` with `facts.BySourceChunk` to
+close the provenance loop: every fact has `source_chunk_id` populated, but
+before this layer existed there was no way to look at the chunk a fact was
+distilled from — `facts get <id>` reported the id and nowhere to go next.
+`facts.BySourceChunk` (unlike `facts.List`/`Search`) includes tombstoned
+facts, since a superseded fact is still legitimate provenance for what a
+chunk's text says.
+
+`facts list` (`facts.List`) is the query-free counterpart to `facts search`
+— same `until IS NULL` default-exclusion convention, plus `--since`/`--until`
+(on `session_date`) and `--min-confidence`.
+
+---
+
 ## Facts Layer
 
 A distilled, structured layer of subject-predicate-object claims sitting
@@ -410,6 +458,8 @@ pull the distill model (OLLAMA_DISTILL_MODEL)`, matching NFR-1.
 
 **2026-08-24** — Added a `model` column to `embeddings`, `SchemaVersion` "2" → "3". Existing DBs must be deleted and re-mined (same policy as above). Prerequisite for supporting a second embedding provider (OpenRouter, alongside Ollama): search now filters to the currently configured model's rows and warns on a mismatch instead of silently mis-scoring vectors of a different dimensionality; `session-indexer embed` re-embeds foreign-model rows in place, so a *future* provider/model switch no longer needs a wipe (only this one-time schema bump does).
 
+**2026-08-26** — Added `internal/browse` and the `sessions`/`list`/`show`/`facts list` verbs (see "Browsing" above). **No `SchemaVersion` change, no re-mine required** — pure read-only additions over the existing schema.
+
 ---
 
 ## File Layout
@@ -433,8 +483,10 @@ session-indexer/
 │   │   └── search.go        — exhaustive cosine; FTS5 fallback; Stats
 │   ├── distill/
 │   │   └── distill.go       — Ollama generate client + orchestration (confidence gate, supersession)
-│   └── facts/
-│       └── facts.go         — read verbs: search (FTS5), get, related
+│   ├── facts/
+│   │   └── facts.go         — read verbs: search (FTS5), list, get, related, bySourceChunk
+│   └── browse/
+│       └── browse.go        — read verbs w/ no query: listChunks, getChunk, days, sessions
 ├── docs/
 │   ├── requirements.md
 │   ├── use-cases.md

--- a/internal/browse/browse.go
+++ b/internal/browse/browse.go
@@ -1,0 +1,176 @@
+// Package browse provides read-only enumeration over stored chunks —
+// list/show without a query, as distinct from internal/search's ranking.
+// Deliberately its own package: internal/search's doc comment scopes it to
+// ranked retrieval, and browse.ListChunks/GetChunk return internal.ChunkSummary
+// (has an ID, no Score) rather than internal.SearchResult (has a Score,
+// meaningless when nothing was ranked).
+//
+// session_date, not session_id, is the default rollup axis: `--resume` keeps
+// one session_id alive for months, so grouping by session_id in practice
+// produces a few huge buckets and many single-digit ones, while session_date
+// gives evenly sized buckets that match how people recall work. No index
+// exists on session_date by design — a full scan over the expected corpus
+// size (thousands of chunks) is single-digit milliseconds, and adding one
+// would force a schema bump (and the re-mine that comes with it) for no
+// measurable gain.
+package browse
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/valpere/session-indexer/internal"
+)
+
+// ListOpts filters ListChunks. Zero-value string fields mean "no filter";
+// Limit is applied as-is (callers, e.g. a Cobra flag, own the default).
+type ListOpts struct {
+	Limit   int
+	Since   string // YYYY-MM-DD inclusive; "" = unbounded
+	Until   string // YYYY-MM-DD inclusive; "" = unbounded
+	Role    string // "user" | "assistant"; "" = both
+	Session string // exact session_id; "" = all
+}
+
+// dateLayout is the stored format for chunks.session_date.
+const dateLayout = "2006-01-02"
+
+func validateDate(field, s string) error {
+	if s == "" {
+		return nil
+	}
+	if _, err := time.Parse(dateLayout, s); err != nil {
+		return fmt.Errorf("invalid %s %q: want YYYY-MM-DD", field, s)
+	}
+	return nil
+}
+
+// ListChunks returns chunks newest-first (by session_date, then id — id
+// alone is insufficient: re-mining an older JSONL later inserts rows whose
+// id is high but whose session_date is old, and date order is what a
+// browse view should honor).
+func ListChunks(d *sql.DB, o ListOpts) ([]internal.ChunkSummary, error) {
+	if err := validateDate("since", o.Since); err != nil {
+		return nil, err
+	}
+	if err := validateDate("until", o.Until); err != nil {
+		return nil, err
+	}
+	q := `SELECT c.id, c.session_id, c.session_date, c.role, c.content,
+	             e.chunk_id IS NOT NULL, dc.chunk_id IS NOT NULL
+	      FROM chunks c
+	      LEFT JOIN embeddings e ON e.chunk_id = c.id
+	      LEFT JOIN distilled_chunks dc ON dc.chunk_id = c.id
+	      WHERE 1=1`
+	var args []any
+	if o.Since != "" {
+		q += ` AND c.session_date >= ?`
+		args = append(args, o.Since)
+	}
+	if o.Until != "" {
+		q += ` AND c.session_date <= ?`
+		args = append(args, o.Until)
+	}
+	if o.Role != "" {
+		q += ` AND c.role = ?`
+		args = append(args, o.Role)
+	}
+	if o.Session != "" {
+		q += ` AND c.session_id = ?`
+		args = append(args, o.Session)
+	}
+	q += ` ORDER BY c.session_date DESC, c.id DESC LIMIT ?`
+	args = append(args, o.Limit)
+
+	rows, err := d.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list chunks: %w", err)
+	}
+	defer rows.Close()
+
+	var out []internal.ChunkSummary
+	for rows.Next() {
+		var c internal.ChunkSummary
+		if err := rows.Scan(&c.ID, &c.SessionID, &c.SessionDate, &c.Role, &c.Content,
+			&c.HasEmbedding, &c.Distilled); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// GetChunk returns one chunk by id, or a wrapped sql.ErrNoRows when absent.
+func GetChunk(d *sql.DB, id int64) (internal.ChunkSummary, error) {
+	var c internal.ChunkSummary
+	err := d.QueryRow(
+		`SELECT c.id, c.session_id, c.session_date, c.role, c.content,
+		        e.chunk_id IS NOT NULL, dc.chunk_id IS NOT NULL
+		 FROM chunks c
+		 LEFT JOIN embeddings e ON e.chunk_id = c.id
+		 LEFT JOIN distilled_chunks dc ON dc.chunk_id = c.id
+		 WHERE c.id = ?`, id).
+		Scan(&c.ID, &c.SessionID, &c.SessionDate, &c.Role, &c.Content,
+			&c.HasEmbedding, &c.Distilled)
+	if err != nil {
+		return internal.ChunkSummary{}, fmt.Errorf("chunk %d: %w", id, err)
+	}
+	return c, nil
+}
+
+// Days rolls chunks up by session_date, newest first — the default view
+// for `sessions` (see package doc for why session_date, not session_id).
+func Days(d *sql.DB) ([]internal.DaySummary, error) {
+	rows, err := d.Query(
+		`SELECT c.session_date, COUNT(*), COUNT(e.chunk_id), COUNT(dc.chunk_id),
+		        COUNT(DISTINCT c.session_id)
+		 FROM chunks c
+		 LEFT JOIN embeddings e ON e.chunk_id = c.id
+		 LEFT JOIN distilled_chunks dc ON dc.chunk_id = c.id
+		 GROUP BY c.session_date
+		 ORDER BY c.session_date DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("days rollup: %w", err)
+	}
+	defer rows.Close()
+
+	var out []internal.DaySummary
+	for rows.Next() {
+		var s internal.DaySummary
+		if err := rows.Scan(&s.SessionDate, &s.Chunks, &s.Embedded, &s.Distilled, &s.Sessions); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// Sessions rolls chunks up by session_id, most-recently-active first — the
+// `--by-session` view (see package doc: skewed on purpose, to make the
+// --resume-collapses-months behavior visible rather than surprising).
+func Sessions(d *sql.DB) ([]internal.SessionSummary, error) {
+	rows, err := d.Query(
+		`SELECT c.session_id, COUNT(*), COUNT(e.chunk_id), COUNT(dc.chunk_id),
+		        MIN(c.session_date), MAX(c.session_date)
+		 FROM chunks c
+		 LEFT JOIN embeddings e ON e.chunk_id = c.id
+		 LEFT JOIN distilled_chunks dc ON dc.chunk_id = c.id
+		 GROUP BY c.session_id
+		 ORDER BY MAX(c.session_date) DESC, COUNT(*) DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("sessions rollup: %w", err)
+	}
+	defer rows.Close()
+
+	var out []internal.SessionSummary
+	for rows.Next() {
+		var s internal.SessionSummary
+		if err := rows.Scan(&s.SessionID, &s.Chunks, &s.Embedded, &s.Distilled,
+			&s.FirstDate, &s.LastDate); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}

--- a/internal/browse/browse.go
+++ b/internal/browse/browse.go
@@ -46,6 +46,16 @@ func validateDate(field, s string) error {
 	return nil
 }
 
+// validateLimit rejects a negative Limit — SQLite treats a negative LIMIT
+// as "no limit at all" rather than an error, which would silently return
+// every row instead of the requested (small) page.
+func validateLimit(n int) error {
+	if n < 0 {
+		return fmt.Errorf("invalid limit %d: must be >= 0", n)
+	}
+	return nil
+}
+
 // ListChunks returns chunks newest-first (by session_date, then id — id
 // alone is insufficient: re-mining an older JSONL later inserts rows whose
 // id is high but whose session_date is old, and date order is what a
@@ -55,6 +65,9 @@ func ListChunks(d *sql.DB, o ListOpts) ([]internal.ChunkSummary, error) {
 		return nil, err
 	}
 	if err := validateDate("until", o.Until); err != nil {
+		return nil, err
+	}
+	if err := validateLimit(o.Limit); err != nil {
 		return nil, err
 	}
 	q := `SELECT c.id, c.session_id, c.session_date, c.role, c.content,

--- a/internal/browse/browse_test.go
+++ b/internal/browse/browse_test.go
@@ -1,0 +1,212 @@
+package browse
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/valpere/session-indexer/internal"
+	"github.com/valpere/session-indexer/internal/db"
+)
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	d, err := db.Open(filepath.Join(t.TempDir(), "sessions.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+func insertChunk(t *testing.T, d *sql.DB, sessionID, date, role string, msgIdx int) int64 {
+	t.Helper()
+	id, inserted, err := db.InsertChunk(d, internal.Chunk{
+		SessionID: sessionID, SessionDate: date, Role: role,
+		MessageIndex: msgIdx, ChunkIndex: 0, Content: "content " + date,
+		CreatedAt: date + "T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("InsertChunk: %v", err)
+	}
+	if !inserted {
+		t.Fatalf("InsertChunk: expected a new row for %s/%d", sessionID, msgIdx)
+	}
+	return id
+}
+
+func TestListChunksEmptyStore(t *testing.T) {
+	d := openTestDB(t)
+	res, err := ListChunks(d, ListOpts{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListChunks: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("results = %+v, want none on empty store", res)
+	}
+}
+
+func TestListChunksOrdersByDateDescThenID(t *testing.T) {
+	d := openTestDB(t)
+	// Insert an "old" chunk (low date) AFTER a "new" one (high id, old date) —
+	// mirrors re-mining an older JSONL later. id order must not win over date.
+	insertChunk(t, d, "s1", "2026-08-20", "user", 0)
+	oldButLastInserted := insertChunk(t, d, "s1", "2026-06-01", "user", 1)
+	newest := insertChunk(t, d, "s1", "2026-08-25", "user", 2)
+
+	res, err := ListChunks(d, ListOpts{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListChunks: %v", err)
+	}
+	if len(res) != 3 {
+		t.Fatalf("got %d results, want 3", len(res))
+	}
+	if res[0].ID != newest {
+		t.Fatalf("first result id = %d, want newest %d (date order, not id order)", res[0].ID, newest)
+	}
+	if res[len(res)-1].ID != oldButLastInserted {
+		t.Fatalf("last result id = %d, want oldest-dated %d despite being inserted last", res[len(res)-1].ID, oldButLastInserted)
+	}
+}
+
+func TestListChunksFilters(t *testing.T) {
+	d := openTestDB(t)
+	insertChunk(t, d, "s1", "2026-08-01", "user", 0)
+	insertChunk(t, d, "s1", "2026-08-10", "assistant", 1)
+	insertChunk(t, d, "s2", "2026-08-20", "user", 0)
+
+	cases := []struct {
+		name string
+		opts ListOpts
+		want int
+	}{
+		{"since", ListOpts{Limit: 10, Since: "2026-08-05"}, 2},
+		{"until", ListOpts{Limit: 10, Until: "2026-08-05"}, 1},
+		{"role", ListOpts{Limit: 10, Role: "assistant"}, 1},
+		{"session", ListOpts{Limit: 10, Session: "s2"}, 1},
+		{"limit", ListOpts{Limit: 1}, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := ListChunks(d, tc.opts)
+			if err != nil {
+				t.Fatalf("ListChunks: %v", err)
+			}
+			if len(res) != tc.want {
+				t.Fatalf("got %d results, want %d", len(res), tc.want)
+			}
+		})
+	}
+}
+
+func TestListChunksInvalidDate(t *testing.T) {
+	d := openTestDB(t)
+	if _, err := ListChunks(d, ListOpts{Limit: 10, Since: "not-a-date"}); err == nil {
+		t.Fatal("ListChunks: expected error for invalid since date")
+	}
+	if _, err := ListChunks(d, ListOpts{Limit: 10, Until: "2026/08/01"}); err == nil {
+		t.Fatal("ListChunks: expected error for invalid until date")
+	}
+}
+
+func TestListChunksHasEmbeddingAndDistilledFlags(t *testing.T) {
+	d := openTestDB(t)
+	id := insertChunk(t, d, "s1", "2026-08-01", "user", 0)
+	if err := db.InsertEmbedding(d, id, []byte{0, 0, 0, 0}, "ollama:bge-m3:latest"); err != nil {
+		t.Fatalf("InsertEmbedding: %v", err)
+	}
+	if err := db.MarkChunkDistilled(d, id, "2026-08-01T00:00:00Z"); err != nil {
+		t.Fatalf("MarkChunkDistilled: %v", err)
+	}
+	other := insertChunk(t, d, "s1", "2026-08-02", "user", 1)
+
+	res, err := ListChunks(d, ListOpts{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListChunks: %v", err)
+	}
+	byID := map[int64]internal.ChunkSummary{}
+	for _, c := range res {
+		byID[c.ID] = c
+	}
+	if !byID[id].HasEmbedding || !byID[id].Distilled {
+		t.Fatalf("chunk %d = %+v, want HasEmbedding and Distilled true", id, byID[id])
+	}
+	if byID[other].HasEmbedding || byID[other].Distilled {
+		t.Fatalf("chunk %d = %+v, want both false", other, byID[other])
+	}
+}
+
+func TestGetChunkFound(t *testing.T) {
+	d := openTestDB(t)
+	id := insertChunk(t, d, "s1", "2026-08-01", "user", 0)
+	c, err := GetChunk(d, id)
+	if err != nil {
+		t.Fatalf("GetChunk: %v", err)
+	}
+	if c.ID != id || c.SessionID != "s1" || c.SessionDate != "2026-08-01" {
+		t.Fatalf("GetChunk = %+v, want id=%d session=s1 date=2026-08-01", c, id)
+	}
+}
+
+func TestGetChunkMissing(t *testing.T) {
+	d := openTestDB(t)
+	if _, err := GetChunk(d, 9999); err == nil {
+		t.Fatal("GetChunk: expected error for missing chunk id")
+	}
+}
+
+func TestDaysRollup(t *testing.T) {
+	d := openTestDB(t)
+	insertChunk(t, d, "s1", "2026-08-01", "user", 0)
+	insertChunk(t, d, "s2", "2026-08-01", "user", 0) // same date, different session
+	insertChunk(t, d, "s1", "2026-08-02", "user", 1)
+
+	res, err := Days(d)
+	if err != nil {
+		t.Fatalf("Days: %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("got %d day rows, want 2", len(res))
+	}
+	// newest first
+	if res[0].SessionDate != "2026-08-02" {
+		t.Fatalf("first day = %s, want 2026-08-02 (newest first)", res[0].SessionDate)
+	}
+	var d1 internal.DaySummary
+	for _, r := range res {
+		if r.SessionDate == "2026-08-01" {
+			d1 = r
+		}
+	}
+	if d1.Chunks != 2 || d1.Sessions != 2 {
+		t.Fatalf("2026-08-01 rollup = %+v, want Chunks=2 Sessions=2", d1)
+	}
+}
+
+func TestSessionsRollup(t *testing.T) {
+	d := openTestDB(t)
+	insertChunk(t, d, "s1", "2026-06-01", "user", 0)
+	insertChunk(t, d, "s1", "2026-08-01", "user", 1) // s1 spans months
+	insertChunk(t, d, "s2", "2026-08-02", "user", 0)
+
+	res, err := Sessions(d)
+	if err != nil {
+		t.Fatalf("Sessions: %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("got %d session rows, want 2", len(res))
+	}
+	var s1 internal.SessionSummary
+	for _, r := range res {
+		if r.SessionID == "s1" {
+			s1 = r
+		}
+	}
+	if s1.Chunks != 2 || s1.FirstDate != "2026-06-01" || s1.LastDate != "2026-08-01" {
+		t.Fatalf("s1 rollup = %+v, want Chunks=2 FirstDate=2026-06-01 LastDate=2026-08-01", s1)
+	}
+	// most-recently-active first: s2 (2026-08-02) before s1 (last active 2026-08-01)
+	if res[0].SessionID != "s2" {
+		t.Fatalf("first session = %s, want s2 (most recently active)", res[0].SessionID)
+	}
+}

--- a/internal/browse/browse_test.go
+++ b/internal/browse/browse_test.go
@@ -99,6 +99,14 @@ func TestListChunksFilters(t *testing.T) {
 	}
 }
 
+func TestListChunksNegativeLimit(t *testing.T) {
+	d := openTestDB(t)
+	insertChunk(t, d, "s1", "2026-08-01", "user", 0)
+	if _, err := ListChunks(d, ListOpts{Limit: -1}); err == nil {
+		t.Fatal("ListChunks: expected error for negative limit (SQLite treats it as unbounded)")
+	}
+}
+
 func TestListChunksInvalidDate(t *testing.T) {
 	d := openTestDB(t)
 	if _, err := ListChunks(d, ListOpts{Limit: 10, Since: "not-a-date"}); err == nil {

--- a/internal/facts/facts.go
+++ b/internal/facts/facts.go
@@ -101,6 +101,12 @@ type ListOpts struct {
 // browse counterpart to Search. Mirrors Search's until IS NULL convention
 // for excluding tombstoned facts by default.
 func List(d *sql.DB, o ListOpts) ([]internal.Fact, error) {
+	// SQLite treats a negative LIMIT as "no limit at all" rather than an
+	// error, which would silently return every row instead of the
+	// requested (small) page — reject it up front instead.
+	if o.Limit < 0 {
+		return nil, fmt.Errorf("invalid limit %d: must be >= 0", o.Limit)
+	}
 	q := `SELECT id, subject, predicate, object, confidence,
 	             source_chunk_id, session_date, created_at, until, superseded_by
 	      FROM facts WHERE 1=1`

--- a/internal/facts/facts.go
+++ b/internal/facts/facts.go
@@ -88,6 +88,65 @@ func Related(d *sql.DB, id int64) ([]internal.Fact, error) {
 	return append(incoming, outgoing...), nil
 }
 
+// ListOpts filters List. Zero-value fields mean "no filter"; Limit is
+// applied as-is (callers, e.g. a Cobra flag, own the default).
+type ListOpts struct {
+	Limit          int
+	Since, Until   string // YYYY-MM-DD inclusive; "" = unbounded
+	MinConfidence  float64
+	IncludeExpired bool
+}
+
+// List returns facts newest-first with no query term required — the
+// browse counterpart to Search. Mirrors Search's until IS NULL convention
+// for excluding tombstoned facts by default.
+func List(d *sql.DB, o ListOpts) ([]internal.Fact, error) {
+	q := `SELECT id, subject, predicate, object, confidence,
+	             source_chunk_id, session_date, created_at, until, superseded_by
+	      FROM facts WHERE 1=1`
+	var args []any
+	if !o.IncludeExpired {
+		q += ` AND until IS NULL`
+	}
+	if o.Since != "" {
+		q += ` AND session_date >= ?`
+		args = append(args, o.Since)
+	}
+	if o.Until != "" {
+		q += ` AND session_date <= ?`
+		args = append(args, o.Until)
+	}
+	if o.MinConfidence > 0 {
+		q += ` AND confidence >= ?`
+		args = append(args, o.MinConfidence)
+	}
+	q += ` ORDER BY session_date DESC, id DESC LIMIT ?`
+	args = append(args, o.Limit)
+
+	rows, err := d.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("facts list: %w", err)
+	}
+	defer rows.Close()
+	return scanFacts(rows)
+}
+
+// BySourceChunk returns every fact distilled from the given chunk —
+// including tombstoned ones, since a superseded fact is still relevant
+// provenance for that chunk's text (unlike List/Search, which default to
+// current facts for a query result).
+func BySourceChunk(d *sql.DB, chunkID int64) ([]internal.Fact, error) {
+	rows, err := d.Query(
+		`SELECT id, subject, predicate, object, confidence,
+		        source_chunk_id, session_date, created_at, until, superseded_by
+		 FROM facts WHERE source_chunk_id = ? ORDER BY id`, chunkID)
+	if err != nil {
+		return nil, fmt.Errorf("facts by source chunk: %w", err)
+	}
+	defer rows.Close()
+	return scanFacts(rows)
+}
+
 // ftsMatchExpr builds an OR of quoted terms from the query for keyword
 // recall — the same per-term-OR approach as internal/search.ftsMatchExpr
 // (unexported there; reimplemented here rather than shared, matching this

--- a/internal/facts/facts_test.go
+++ b/internal/facts/facts_test.go
@@ -31,6 +31,21 @@ func insertFact(t *testing.T, d *sql.DB, subject, predicate, object string) int6
 	return id
 }
 
+// insertFactFull is insertFact with control over date/confidence/source
+// chunk, for List/BySourceChunk tests that need to vary those fields.
+func insertFactFull(t *testing.T, d *sql.DB, subject, predicate, object, date string, confidence float64, sourceChunkID int64) int64 {
+	t.Helper()
+	id, err := db.InsertFact(d, internal.Fact{
+		Subject: subject, Predicate: predicate, Object: object,
+		Confidence: confidence, SourceChunkID: sourceChunkID,
+		SessionDate: date, CreatedAt: date + "T10:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("InsertFact: %v", err)
+	}
+	return id
+}
+
 func TestSearchEmptyStore(t *testing.T) {
 	d := openTestDB(t)
 	res, err := Search(d, "anything", 5, false)
@@ -141,5 +156,131 @@ func TestRelatedDepth1(t *testing.T) {
 	}
 	if len(related) != 1 || related[0].ID != oldID {
 		t.Fatalf("Related(new) = %+v, want [oldID=%d]", related, oldID)
+	}
+}
+
+func TestListEmptyStore(t *testing.T) {
+	d := openTestDB(t)
+	res, err := List(d, ListOpts{Limit: 10})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("results = %+v, want none on empty store", res)
+	}
+}
+
+func TestListExcludesExpiredByDefault(t *testing.T) {
+	d := openTestDB(t)
+	oldID := insertFactFull(t, d, "project", "status", "not started", "2026-07-01", 0.9, 0)
+	newID := insertFactFull(t, d, "project", "status", "in progress", "2026-07-02", 0.9, 0)
+	if _, err := db.SupersedeFact(d, newID, oldID, "2026-07-03T10:00:00Z"); err != nil {
+		t.Fatalf("SupersedeFact: %v", err)
+	}
+
+	res, err := List(d, ListOpts{Limit: 10})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(res) != 1 || res[0].ID != newID {
+		t.Fatalf("List = %+v, want only [newID=%d]", res, newID)
+	}
+
+	withExpired, err := List(d, ListOpts{Limit: 10, IncludeExpired: true})
+	if err != nil {
+		t.Fatalf("List(IncludeExpired): %v", err)
+	}
+	if len(withExpired) != 2 {
+		t.Fatalf("List(IncludeExpired) = %+v, want both facts", withExpired)
+	}
+}
+
+func TestListFilters(t *testing.T) {
+	d := openTestDB(t)
+	insertFactFull(t, d, "a", "is", "x", "2026-07-01", 0.5, 0)
+	insertFactFull(t, d, "b", "is", "y", "2026-07-10", 0.95, 0)
+	insertFactFull(t, d, "c", "is", "z", "2026-07-20", 0.7, 0)
+
+	cases := []struct {
+		name string
+		opts ListOpts
+		want int
+	}{
+		{"since", ListOpts{Limit: 10, Since: "2026-07-05"}, 2},
+		{"until", ListOpts{Limit: 10, Until: "2026-07-05"}, 1},
+		{"min-confidence", ListOpts{Limit: 10, MinConfidence: 0.9}, 1},
+		{"limit", ListOpts{Limit: 1}, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := List(d, tc.opts)
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+			if len(res) != tc.want {
+				t.Fatalf("got %d results, want %d", len(res), tc.want)
+			}
+		})
+	}
+}
+
+func TestBySourceChunk(t *testing.T) {
+	d := openTestDB(t)
+	chunkID, inserted, err := db.InsertChunk(d, internal.Chunk{
+		SessionID: "s1", SessionDate: "2026-07-01", Role: "assistant",
+		MessageIndex: 0, ChunkIndex: 0, Content: "some content",
+		CreatedAt: "2026-07-01T10:00:00Z",
+	})
+	if err != nil || !inserted {
+		t.Fatalf("InsertChunk: inserted=%v err=%v", inserted, err)
+	}
+	otherChunkID, _, err := db.InsertChunk(d, internal.Chunk{
+		SessionID: "s1", SessionDate: "2026-07-01", Role: "assistant",
+		MessageIndex: 1, ChunkIndex: 0, Content: "other content",
+		CreatedAt: "2026-07-01T10:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("InsertChunk (other): %v", err)
+	}
+
+	f1 := insertFactFull(t, d, "a", "is", "x", "2026-07-01", 0.9, chunkID)
+	f2 := insertFactFull(t, d, "a", "is", "y", "2026-07-01", 0.9, chunkID)
+	insertFactFull(t, d, "b", "is", "z", "2026-07-01", 0.9, otherChunkID)
+
+	res, err := BySourceChunk(d, chunkID)
+	if err != nil {
+		t.Fatalf("BySourceChunk: %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("BySourceChunk(%d) = %+v, want 2 facts", chunkID, res)
+	}
+	ids := map[int64]bool{res[0].ID: true, res[1].ID: true}
+	if !ids[f1] || !ids[f2] {
+		t.Fatalf("BySourceChunk(%d) = %+v, want [%d, %d]", chunkID, res, f1, f2)
+	}
+}
+
+func TestBySourceChunkIncludesTombstoned(t *testing.T) {
+	d := openTestDB(t)
+	chunkID, _, err := db.InsertChunk(d, internal.Chunk{
+		SessionID: "s1", SessionDate: "2026-07-01", Role: "assistant",
+		MessageIndex: 0, ChunkIndex: 0, Content: "content",
+		CreatedAt: "2026-07-01T10:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("InsertChunk: %v", err)
+	}
+	oldID := insertFactFull(t, d, "project", "status", "not started", "2026-07-01", 0.9, chunkID)
+	newID := insertFactFull(t, d, "project", "status", "in progress", "2026-07-02", 0.9, chunkID)
+	if _, err := db.SupersedeFact(d, newID, oldID, "2026-07-03T10:00:00Z"); err != nil {
+		t.Fatalf("SupersedeFact: %v", err)
+	}
+
+	res, err := BySourceChunk(d, chunkID)
+	if err != nil {
+		t.Fatalf("BySourceChunk: %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("BySourceChunk = %+v, want both facts (including tombstoned)", res)
 	}
 }

--- a/internal/facts/facts_test.go
+++ b/internal/facts/facts_test.go
@@ -224,6 +224,14 @@ func TestListFilters(t *testing.T) {
 	}
 }
 
+func TestListNegativeLimit(t *testing.T) {
+	d := openTestDB(t)
+	insertFactFull(t, d, "a", "is", "x", "2026-07-01", 0.9, 0)
+	if _, err := List(d, ListOpts{Limit: -1}); err == nil {
+		t.Fatal("List: expected error for negative limit (SQLite treats it as unbounded)")
+	}
+}
+
 func TestBySourceChunk(t *testing.T) {
 	d := openTestDB(t)
 	chunkID, inserted, err := db.InsertChunk(d, internal.Chunk{

--- a/internal/types.go
+++ b/internal/types.go
@@ -34,3 +34,36 @@ type Fact struct {
 	Until         *string // tombstone timestamp; nil = currently valid
 	SupersededBy  *int64  // id of the fact that superseded this one
 }
+
+// ChunkSummary is one stored chunk as returned by the browse verbs
+// (list/show) — distinct from SearchResult, whose Score is meaningless
+// when nothing was ranked, and which lacks ID/SessionID needed to browse.
+type ChunkSummary struct {
+	ID           int64
+	SessionID    string
+	SessionDate  string
+	Role         string
+	Content      string
+	HasEmbedding bool
+	Distilled    bool
+}
+
+// DaySummary rolls up chunks by session_date, the default browse axis
+// (session_id is a poor axis in practice — see internal/browse doc).
+type DaySummary struct {
+	SessionDate string
+	Chunks      int
+	Embedded    int
+	Distilled   int
+	Sessions    int // distinct session_ids touching this date
+}
+
+// SessionSummary rolls up chunks by session_id (the --by-session view).
+type SessionSummary struct {
+	SessionID string
+	Chunks    int
+	Embedded  int
+	Distilled int
+	FirstDate string
+	LastDate  string
+}


### PR DESCRIPTION
## Summary

Product Hunt reviewer feedback: no visibility into what got indexed without
already knowing what to search for. `stats` gives aggregates, `search` and
`facts search` both require a query term — nothing in between.

Adds four thin read-only verbs. No schema version change, no forced re-mine.

- `sessions [--by-session]` — roll up by day (default) or `session_id`
- `list [--limit/--since/--until/--role/--session]` — newest-first chunks
- `show <chunk-id>` — full chunk text + facts distilled from it, closing the
  `facts get <id>` → `source_chunk_id` → *(dead end)* provenance gap
- `facts list [--limit/--since/--until/--min-confidence/--include-expired]`
  — query-free counterpart to `facts search`

**Design notes** (see `docs/architecture.md`'s new "Browsing" section for
the full rationale):
- `sessions` defaults to `session_date`, not `session_id`: `--resume` keeps
  one `sessionId` alive for months, so `session_id` produces a few huge
  buckets and many single-chunk ones in practice (verified against the live
  DB: 12 distinct ids for 26k+ chunks, one spanning 2 months).
- No index added on `session_date` — measured `ORDER BY session_date DESC
  LIMIT N` at single-digit ms on the live 26k-chunk/150MB store; an index
  would force another schema bump (and re-mine) for no measurable gain.

## Test plan

- [x] `go build ./... && go vet ./... && gofmt -l . && go test -race ./...`
- [x] New unit tests: `internal/browse/browse_test.go` (empty store, date
  ordering under out-of-order insertion, filters, embedding/distill flags,
  missing-chunk error, day/session rollups) and additions to
  `internal/facts/facts_test.go` (`List` filters + tombstone exclusion,
  `BySourceChunk` incl. tombstoned)
- [x] End-to-end smoke test against a real 5,882-chunk store (mined from
  this project's own transcript into a disposable scratch DB — the live
  `.claude/sessions.db` turned out to be stuck on schema v2, an unrelated
  pre-existing gap, not touched here): `sessions`, `sessions --by-session`,
  `list` with filters, invalid-date error path, `show` on a present and a
  missing id, and the full `facts get` → `show` provenance loop with a
  real fact

Issue: https://github.com/valpere/session-indexer/issues/64