### PR TITLE
chore: gitignore per-machine sessions.db backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ vendor/
 .claude/sessions.db
 .claude/sessions.db-shm
 .claude/sessions.db-wal
+.claude/sessions.db.*-backup-*
 
 # Claude Code local-only settings — never commit (per-machine hook wiring)
 .claude/settings.local.json


### PR DESCRIPTION
Docs/config-only. Closes a gap found while fixing #66 — a manual DB backup file wasn't covered by the existing exact-match `.claude/sessions.db` gitignore entry.