### PR TITLE
docs: versioning policy, CHANGELOG.md, v2->v3 migration guide; bump to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ full per-PR history.
 
 ## [0.1.0] - 2026-06-29
 
+### Added
+
 Initial release. Core pipeline: `mine` (JSONL → SQLite, idempotent,
 chunked on paragraph boundaries with a noise filter), `embed` (Ollama
 `bge-m3:latest`, float32 BLOB storage, availability probe with graceful

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,90 @@
+# Changelog
+
+All notable changes to `session-indexer` are documented here. Format loosely
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning
+follows the project-specific [SemVer policy](docs/versioning.md) (any schema
+bump gets at least a MINOR release, never a PATCH).
+
+Each GitHub Release also carries auto-generated, PR-by-PR notes — this file
+is the shorter, thematically-grouped summary; see
+[Releases](https://github.com/valpere/session-indexer/releases) for the
+full per-PR history.
+
+## [Unreleased]
+
+## [0.3.0] - 2026-08-27
+
+### Added
+- Browse the index without a query: `sessions` (roll up by day or, with
+  `--by-session`, by raw `session_id`), `list` (newest-first chunks with
+  date/role/session filters), `show <chunk-id>` (full chunk text plus the
+  facts distilled from it — closes the `facts get <id>` →
+  `source_chunk_id` provenance gap), and `facts list` (query-free
+  counterpart to `facts search`). No schema change, no forced re-mine.
+
+### Changed
+- `embeddings` now records a `model` tag per row (`SchemaVersion` 2 → 3).
+  `search` filters to the currently configured model's rows and warns on
+  a mismatch instead of silently scoring vectors of a different
+  dimensionality; `embed` re-embeds foreign-model rows in place, so
+  switching embedding provider/model no longer requires a full DB wipe
+  (only this one-time schema bump does — see
+  [`docs/migrations/schema-v2-to-v3.md`](docs/migrations/schema-v2-to-v3.md)
+  for an in-place, no-data-loss upgrade path).
+- CI hardening: `govulncheck` now runs on a weekly schedule in addition to
+  push/PR, files a tracked issue on a scheduled failure, and is pinned as
+  a `go.mod` tool dependency (Dependabot-tracked) instead of an unpinned
+  `go install ...@latest`. The failure-notification step's `issues:
+  write` permission is scoped to its own job, never granted to ordinary
+  push/PR runs.
+
+### Fixed
+- A negative `--limit` on `list`/`facts list` is now rejected — SQLite
+  treats a negative `LIMIT` as unbounded, which would have silently
+  returned every row instead of erroring.
+
+## [0.2.0] - 2026-07-24
+
+### Added
+- Facts layer: `distill` extracts structured subject-predicate-object
+  claims from mined chunks via an LLM call (Ollama `/api/generate`,
+  default `glm-5.2:cloud`, `--model` override), with a deterministic
+  confidence gate and automatic supersession (bounded-context judgment,
+  validated against already-tombstoned/out-of-context fact ids).
+  `facts search/get/related/supersede` query the resulting claim store,
+  separate from raw-text `search`.
+- `distill` concurrency (`--concurrency`), retry with exponential backoff
+  on transient failures (`--retries`), a circuit breaker for persistent
+  outages (`--circuit-breaker`), a `--limit` cap, and live progress
+  output. Safe to interrupt (Ctrl-C/SIGTERM) — resumes cleanly on the
+  next run, no partial-chunk loss.
+- Release workflow: cross-compiled binaries (`linux/amd64`,
+  `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`)
+  attached to a GitHub Release on every `v*` tag push. Scheduled
+  `govulncheck` security scanning and Dependabot.
+
+### Changed
+- Dropped the Python 3 dependency from `session-recall`'s hook scripts in
+  favor of `jq` — matches this project's own pure-Go/bash convention.
+- `session-recall`'s `/recall` skill moved to a single user-level copy;
+  the per-project mechanism (hooks, `.claude/sessions.db`) stays
+  project-local.
+
+### Fixed
+- Patch-pinned `go.mod` to Go 1.26.5, fixing a stdlib CVE
+  (GO-2026-5856) reachable via the CI vulncheck job.
+
+## [0.1.0] - 2026-06-29
+
+Initial release. Core pipeline: `mine` (JSONL → SQLite, idempotent,
+chunked on paragraph boundaries with a noise filter), `embed` (Ollama
+`bge-m3:latest`, float32 BLOB storage, availability probe with graceful
+degradation), `search` (embedding-first exhaustive cosine similarity with
+an FTS5 BM25 fallback), and `stats`. Schema-version guard on every DB
+open (hard error on mismatch, no silent auto-migration, by design). Stop
+hook wiring for automatic per-session indexing.
+
+[Unreleased]: https://github.com/valpere/session-indexer/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/valpere/session-indexer/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/valpere/session-indexer/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/valpere/session-indexer/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -356,7 +356,13 @@ separate top-level `Stop` entries). See Hook Setup above.
 ```
 schema version mismatch (X != Y): delete .claude/sessions.db and re-mine to rebuild
 ```
-Delete the DB and re-run `mine` on your JSONLs — `mine` is idempotent.
+Default path: delete the DB and re-run `mine` on your JSONLs — `mine` is
+idempotent. **But check first** if this is an established project: Claude
+Code prunes old JSONL transcripts after a while, so a long-running DB can
+hold more history than re-mining could actually reconstruct. If your
+current version bumped from schema 2 to 3, an in-place migration that
+loses nothing is available — see
+[`docs/migrations/schema-v2-to-v3.md`](docs/migrations/schema-v2-to-v3.md).
 
 **Search returns poor results / FTS5 fallback:**
 ```bash
@@ -378,3 +384,14 @@ tail -40 ~/.cache/$(basename "$(git rev-parse --show-toplevel)")/hooks.log
 **DB size:** scale assumption is <10k chunks (~40MB vectors in memory). No hard
 limit, but `search` loads all embedding rows into memory for cosine; if the DB
 grows beyond ~50k chunks, revisit.
+
+## Versioning & Releases
+
+[SemVer](https://semver.org/), with one project rule: any release that
+bumps `internal/db.SchemaVersion` gets at least a MINOR bump, never a
+PATCH — treat a MINOR release as potentially requiring a DB migration
+until `v1.0.0` (not yet reached). See [`docs/versioning.md`](docs/versioning.md)
+for the full policy (branching, release cutting) and
+[`CHANGELOG.md`](CHANGELOG.md) for what changed in each release.
+Pre-built binaries for Linux/macOS/Windows are attached to each
+[GitHub Release](https://github.com/valpere/session-indexer/releases).

--- a/cmd/session-indexer/main.go
+++ b/cmd/session-indexer/main.go
@@ -25,7 +25,7 @@ import (
 
 // version is the current release; overridden at build time via
 // -ldflags "-X main.version=x.y.z" (see Makefile).
-var version = "0.2.0"
+var version = "0.3.0"
 
 func main() {
 	var dbPath string

--- a/docs/migrations/schema-v2-to-v3.md
+++ b/docs/migrations/schema-v2-to-v3.md
@@ -1,0 +1,88 @@
+# Migrating `.claude/sessions.db` from schema v2 to v3
+
+Applies when you upgrade `session-indexer` to a version whose
+`internal/db.SchemaVersion` is `"3"` (v0.3.0+) and see:
+
+```
+error: schema version mismatch (2 != 3): delete .claude/sessions.db and re-mine to rebuild
+```
+
+## Read this before you delete anything
+
+`session-indexer`'s general policy — no migration framework, by design —
+is "delete the DB and re-mine your JSONLs." That's the right call for a
+schema change you can't safely automate. But **check what re-mining can
+actually recover before you delete**, especially on a project you've used
+for weeks or months:
+
+```bash
+# How much history does the DB currently hold?
+sqlite3 .claude/sessions.db "SELECT COUNT(*) FROM chunks;"
+sqlite3 .claude/sessions.db "SELECT COUNT(DISTINCT session_id) FROM chunks;"
+
+# How much could a re-mine actually recover right now?
+ls ~/.claude/projects/<your-project-slug>/*.jsonl 2>/dev/null | wc -l
+```
+
+Claude Code prunes old JSONL transcript files after some time. If the chunk
+count is much larger than what the remaining JSONLs could reconstruct,
+**do not delete** — the v2→v3 change is additive and can be applied in
+place instead, with zero data loss.
+
+## What actually changed between v2 and v3
+
+One column. `embeddings` gained `model TEXT NOT NULL` (see PR #56) so
+`search`/`embed` can tell which provider/model produced each stored
+vector, instead of silently mis-scoring or dropping vectors when you
+switch embedding models. Every embedding this schema version has ever
+supported was produced by Ollama's `bge-m3:latest` — no other provider
+path has shipped — so backfilling that single value for every existing
+row is safe.
+
+## In-place migration (recommended over delete-and-re-mine)
+
+```bash
+# 1. Back up first. Non-negotiable — this mutates the live DB.
+cp .claude/sessions.db .claude/sessions.db.v2-backup-$(date +%Y%m%d-%H%M%S)
+
+# 2. Add the missing column, backfilled for every existing row.
+sqlite3 .claude/sessions.db <<'EOF'
+ALTER TABLE embeddings ADD COLUMN model TEXT NOT NULL DEFAULT 'ollama:bge-m3:latest';
+UPDATE meta SET value='3' WHERE key='schema_version';
+EOF
+
+# 3. Bring your session-indexer binary current (if you haven't already).
+go install ./cmd/session-indexer   # or: make install
+
+# 4. Verify nothing was lost — compare against what you recorded in step 0.
+session-indexer stats --db .claude/sessions.db
+sqlite3 .claude/sessions.db "SELECT model, COUNT(*) FROM embeddings GROUP BY model;"
+```
+
+`Chunks`/`Facts`/`Sessions` counts in `stats` must match what you had
+before the `ALTER TABLE` exactly — the migration only adds a column, it
+never touches rows. The `GROUP BY model` query should show exactly one
+model tag, matching your project's actual embedding history (adjust the
+`DEFAULT` value above if you ever used a different `OLLAMA_MODEL` or a
+non-default provider for this project — tag rows individually in that
+case rather than one blanket default).
+
+Once verified, delete the backup (`.claude/sessions.db.v2-backup-*`) or
+keep it — it's gitignored either way (`.claude/sessions.db.*-backup-*`).
+
+## If this isn't your situation
+
+If you're setting up `session-indexer` fresh, or you're fine losing
+history and re-mining from scratch, the documented default path (delete +
+re-mine) is simpler and works exactly as described in the error message
+and `CLAUDE.md`. This guide exists for the case where that default advice
+would be actively harmful — an established project where JSONL pruning
+has already outpaced what the DB holds.
+
+## For a future schema bump
+
+This guide is specific to 2→3. If `SchemaVersion` bumps again later (e.g.
+to `"4"`), check `docs/architecture.md`'s Changelog section and
+`internal/db/schema.sql`'s diff for that specific bump — the "is this
+additive/backfillable in place" question has to be re-asked for each
+transition; the answer here does not generalize.

--- a/docs/migrations/schema-v2-to-v3.md
+++ b/docs/migrations/schema-v2-to-v3.md
@@ -54,7 +54,8 @@ EOF
 # 3. Bring your session-indexer binary current (if you haven't already).
 go install ./cmd/session-indexer   # or: make install
 
-# 4. Verify nothing was lost — compare against what you recorded in step 0.
+# 4. Verify nothing was lost — compare against the counts you recorded
+#    in "Read this before you delete anything" above.
 session-indexer stats --db .claude/sessions.db
 sqlite3 .claude/sessions.db "SELECT model, COUNT(*) FROM embeddings GROUP BY model;"
 ```

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,102 @@
+# Versioning and Release Policy
+
+## Version scheme
+
+Standard [SemVer](https://semver.org/) (`MAJOR.MINOR.PATCH`), with one
+project-specific rule layered on top:
+
+- **Any commit that bumps `internal/db.SchemaVersion` requires at least a
+  MINOR version bump — never a PATCH.** A schema bump is, in practice, a
+  breaking change for existing users (see "Storage" in `CLAUDE.md`: no
+  migration framework by design, the documented recovery path is
+  delete-and-re-mine). SemVer technically allows anything to change within
+  MINOR while the project is pre-1.0 (`0.y.z`), but this rule exists so a
+  schema bump is never mistaken for a routine PATCH — check
+  `docs/architecture.md`'s Changelog section before assuming a release is
+  a safe drop-in upgrade.
+- **PATCH** — bug fixes, dependency bumps, CI/docs changes. No schema
+  change, no CLI behavior change a script depending on `session-indexer`
+  could notice.
+- **MINOR** — new features (new subcommands, new flags, new output
+  fields), or a schema bump per the rule above.
+- **MAJOR** — reserved. See "What 1.0.0 means" below.
+
+## What 1.0.0 means
+
+Not yet declared. At minimum, before cutting `v1.0.0`:
+
+- The `SchemaVersion` bump policy above should have a real answer for
+  "can I upgrade without deleting my DB" beyond "check the migration doc
+  if one exists" — either a proper migration mechanism, or an explicit,
+  permanent decision to keep the current delete-and-re-mine model with
+  1.0 signaling something else (API/CLI surface stability, not schema
+  stability).
+- The CLI surface (subcommands, flags, `--json` output shapes) should be
+  considered something other projects/scripts can depend on without
+  watching every release's changelog.
+
+Until then, treat every `0.x` release as capable of a schema bump; read
+the changelog before upgrading a project you rely on daily.
+
+## Release branching
+
+Trunk-based. All work — features and fixes alike — branches from and
+merges back into `main` via PR (see `CLAUDE.md`'s "Before Any Commit"
+section and the repo's branch-protection rules). A release is just a
+`vX.Y.Z` tag on whatever commit of `main` is current at cut time; there is
+no long-lived `develop` branch and no persistent split between "released"
+and "next" code.
+
+**Rationale:** this is a solo-maintained, single-binary Go project with no
+field reports (yet) of needing to patch an old release while `main` has
+already moved past it. A permanent `develop`/`main` split (git-flow-style)
+would mean an ongoing merge/sync tax paid on every single change, for a
+scenario — hotfixing a stale release — that hasn't happened. That's the
+kind of premature-generality this project's own design principles (see
+global `CLAUDE.md`, YAGNI) argue against paying for up front.
+
+**If a hotfix for an old release is ever actually needed** (bug found in
+`v0.3.0`, but `main` has since moved on to unreleased `v0.4.0`-track
+changes that shouldn't ship yet):
+
+```bash
+git checkout -b release/v0.3 v0.3.0   # branch from the tag, not from main
+# cherry-pick or reimplement the specific fix here
+git tag v0.3.1
+git push origin release/v0.3 v0.3.1   # triggers release.yml on the new tag
+```
+
+This creates the branch retroactively, only when actually needed, scoped
+to exactly the one fix. It is not maintained ahead of time and does not
+need to track `main`.
+
+## Cutting a release
+
+1. Confirm `main` is green (`gh pr checks` / Actions tab) and everything
+   intended for the release has merged.
+2. Decide the version number per the scheme above (check whether anything
+   merged since the last tag bumped `SchemaVersion`).
+3. Update `CHANGELOG.md` with a new `## [X.Y.Z] - YYYY-MM-DD` section.
+   `release.yml`'s `generate_release_notes: true` already produces a
+   PR-title-based changelog on the GitHub Release page itself — the
+   `CHANGELOG.md` entry should be a shorter, thematically-grouped summary
+   (Added/Changed/Fixed), not a duplicate of that raw PR list.
+4. Update `var version` in `cmd/session-indexer/main.go` to match — it's
+   only the fallback used when `git describe --tags --exact-match` can't
+   resolve a tag (see `Makefile`'s `LDFLAGS`), but keeping it current
+   means `go install` between releases still reports something close to
+   accurate.
+5. Commit both (CHANGELOG + version bump) directly to `main` via a small
+   PR (or as the final commit before tagging — either is fine, this is a
+   docs/metadata-only change).
+6. Tag and push:
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+   `.github/workflows/release.yml` triggers on the `v*` tag push, builds
+   binaries for `linux/amd64`, `linux/arm64`, `darwin/amd64`,
+   `darwin/arm64`, and `windows/amd64`, and creates the GitHub Release
+   with those binaries attached plus auto-generated PR-based notes.
+7. Verify: `gh release view vX.Y.Z` — check the binaries are attached and
+   the release isn't marked a draft/prerelease unintentionally.


### PR DESCRIPTION
Prep for cutting the v0.3.0 tag (20 commits since v0.2.0, includes a schema bump). Adds `docs/versioning.md` (SemVer + release-branching policy), `CHANGELOG.md` (backfilled from tag history), and `docs/migrations/schema-v2-to-v3.md` (in-place migration — promoted from investigating why this project's own DB got stuck on schema v2). Docs + one version-string constant only, no logic changes.