### PR TITLE
distill: add --context-cap and --batch flags to cut Ollama call volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ full per-PR history.
 
 ## [Unreleased]
 
+### Added
+- `distill --context-cap` (default 200, previously hardcoded): the per-call
+  facts-context block dominates prompt size — and Ollama Cloud bills by
+  GPU-time, not per token — so the cap is now a tunable cost/quality dial.
+- `distill --batch` (default 1, previously the only behavior): groups N
+  pending chunks into one numbered-chunks Ollama call with per-fact
+  `chunk_index` attribution, cutting call count ~N-fold. The batch retries,
+  fails, and gets marked distilled as a unit; a `--batch 1` call sends the
+  byte-identical pre-batching prompt.
+
 ## [0.3.0] - 2026-08-27
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ happens anyway.
 
 ### Facts Layer
 
-Distilled subject-predicate-object claims, separate from raw-text `search`. `distill` (manual, never hooked into `mine`/Stop-hook budget — `context.Background()`, 120s HTTP timeout) calls Ollama `/api/generate` (`OLLAMA_DISTILL_MODEL` env or `--model` flag, default `glm-5.2:cloud`) per chunk not yet in `distilled_chunks`, feeding it a bounded `CurrentFacts` context (cap 200) for supersession judgment.
+Distilled subject-predicate-object claims, separate from raw-text `search`. `distill` (manual, never hooked into `mine`/Stop-hook budget — `context.Background()`, 120s HTTP timeout) calls Ollama `/api/generate` (`OLLAMA_DISTILL_MODEL` env or `--model` flag, default `glm-5.2:cloud`) for chunks not yet in `distilled_chunks` — `--batch N` (default 1) groups N chunks into one numbered-chunks call with per-fact `chunk_index` attribution (Ollama Cloud bills per call) — feeding it a bounded `CurrentFacts` context (`--context-cap`, default 200) for supersession judgment.
 
 Confidence gate is a **deterministic Go check** (default 0.7), not an LLM-enforced instruction — the model's self-reported confidence is advisory input only. Supersession is judged automatically by the model, but the model may only cite fact ids from the context it was actually given (validated in Go); `SupersedeFact` no-ops (not an error) on an already-tombstoned fact. `facts supersede <new> <old>` is a manual audit/override backstop using the same function. See `docs/architecture.md`'s "Facts Layer" section for the full design rationale (deliberate deviations from litopys).
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ safeguards).
 session-indexer distill --db .claude/sessions.db --threshold 0.7
 # → Distilled 12 chunks: 5 facts stored, 3 below threshold, 1 superseded
 
+# Cost dials for Ollama Cloud (billed by GPU-time per call, not per token):
+# the facts-context block dominates each prompt, and one call per chunk
+# multiplies fast. Smaller context + batched chunks ≈ N× fewer, cheaper
+# calls; both default to the original behavior (200 / 1).
+session-indexer distill --db .claude/sessions.db --context-cap 30 --batch 4
+
 # Query
 session-indexer facts search "implementation status" --db .claude/sessions.db
 # → [7] session-indexer | has | 33 merged PRs (confidence 0.92)

--- a/cmd/session-indexer/main.go
+++ b/cmd/session-indexer/main.go
@@ -265,6 +265,8 @@ func main() {
 	var distillLimit int
 	var distillRetries int
 	var distillCircuitBreaker int
+	var distillContextCap int
+	var distillBatch int
 	distillCmd := &cobra.Command{
 		Use:   "distill",
 		Short: "Extract structured facts from mined chunks (LLM, Ollama)",
@@ -278,7 +280,7 @@ func main() {
 			if dbPath == "" {
 				return fmt.Errorf("--db is required")
 			}
-			return runDistill(dbPath, threshold, distillModel, distillConcurrency, distillLimit, distillRetries, distillCircuitBreaker)
+			return runDistill(dbPath, threshold, distillModel, distillConcurrency, distillLimit, distillRetries, distillCircuitBreaker, distillContextCap, distillBatch)
 		},
 	}
 	distillCmd.Flags().Float64Var(&threshold, "threshold", 0.7, "minimum confidence to store a fact")
@@ -287,6 +289,8 @@ func main() {
 	distillCmd.Flags().IntVar(&distillLimit, "limit", 0, "max chunks to process this run (0 = all pending)")
 	distillCmd.Flags().IntVar(&distillRetries, "retries", 2, "extra attempts for a chunk that errors (e.g. 429), with exponential backoff, before leaving it for the next run")
 	distillCmd.Flags().IntVar(&distillCircuitBreaker, "circuit-breaker", 5, "stop the run after this many consecutive chunks fail all their retries (0 disables; signals a persistent outage, not a blip — e.g. Ollama quota exhausted)")
+	distillCmd.Flags().IntVar(&distillContextCap, "context-cap", 200, "max current facts fed to the distiller for supersession judgment (the context block dominates per-call cost; smaller = cheaper calls)")
+	distillCmd.Flags().IntVar(&distillBatch, "batch", 1, "pending chunks per Ollama call (Ollama cloud bills per call, so batching N chunks cuts call count ~N-fold; the batch retries and gets marked as a unit)")
 
 	var factsLimit int
 	var factsJSON bool
@@ -500,7 +504,7 @@ func runEmbed(dbPath string) error {
 	return nil
 }
 
-func runDistill(dbPath string, threshold float64, model string, concurrency, limit, retries, circuitBreaker int) error {
+func runDistill(dbPath string, threshold float64, model string, concurrency, limit, retries, circuitBreaker, contextCap, batch int) error {
 	d, err := db.Open(dbPath)
 	if err != nil {
 		return err
@@ -521,8 +525,8 @@ func runDistill(dbPath string, threshold float64, model string, concurrency, lim
 	// distill is otherwise a manual, non-time-boxed command, explicitly
 	// exempt from mine's 50s/Stop-hook budget (NFR-4).
 	res, err := distill.Run(ctx, d, cli, distill.Config{
-		Threshold: threshold, ContextCap: 200, Concurrency: concurrency, Limit: limit,
-		MaxRetries: retries, CircuitBreaker: circuitBreaker,
+		Threshold: threshold, ContextCap: contextCap, Concurrency: concurrency, Limit: limit,
+		MaxRetries: retries, CircuitBreaker: circuitBreaker, BatchSize: batch,
 		OnProgress: func(done, total int, res distill.Result) {
 			fmt.Fprintf(os.Stderr, "\rdistill: %d/%d chunks (%d facts, %d below threshold, %d failed) [%s]",
 				done, total, res.FactsInserted, res.BelowThreshold, res.Failed, time.Since(start).Round(time.Second))

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -353,23 +353,27 @@ periodic review unless something distills and tombstones it at index time.
 ### Distill flow
 
 ```
-session-indexer distill --db <path> [--threshold 0.7]
+session-indexer distill --db <path> [--threshold 0.7] [--context-cap 200] [--batch 1]
     │
-    └─ for each chunk in ChunksWithoutFacts (distilled_chunks marker):
+    └─ for each batch of BatchSize chunks in ChunksWithoutFacts
+         │  (distilled_chunks marker; batch=1 is the original behavior):
          │
          ├─ CurrentFacts(limit=ContextCap) — bounded context of
          │  non-tombstoned facts, fed to the model for supersession judgment
          │
-         ├─ POST /api/generate  { model: OLLAMA_DISTILL_MODEL, chunk, existing facts }
-         │  → candidates: [{subject, predicate, object, confidence, supersedes_ids}]
+         ├─ POST /api/generate  { model: OLLAMA_DISTILL_MODEL, chunks, existing facts }
+         │  → candidates: [{subject, predicate, object, confidence,
+         │                  chunk_index, supersedes_ids}]
          │
          ├─ per candidate:
          │    confidence < threshold?  → discard (BelowThreshold++)
-         │    else → InsertFact; for each supersedes_ids entry validated
-         │           against the context actually given → SupersedeFact
+         │    else → InsertFact (attributed to the chunk its chunk_index
+         │           names; absent/out-of-range index → the batch's first
+         │           chunk, never dropped); for each supersedes_ids entry
+         │           validated against the context actually given → SupersedeFact
          │
-         └─ MarkChunkDistilled — regardless of fact count (zero-fact chunks
-            must not be re-distilled forever)
+         └─ MarkChunkDistilled per chunk in the batch — regardless of fact
+            count (zero-fact chunks must not be re-distilled forever)
 ```
 
 `distill` is a separate, manually-invoked subcommand — it never hooks into
@@ -410,10 +414,20 @@ Safeguards:
   `superseded_by` edge; `facts supersede <new> <old>` exists as a manual
   audit/override backstop using the same `SupersedeFact` function
 
-If the current-facts set exceeds `ContextCap` (200), the distill call omits
-context entirely for that chunk and auto-supersession is skipped for it —
-an oversized context blows the prompt budget and the model has nothing
-reliable to judge supersession against.
+If the current-facts set exceeds `ContextCap` (`--context-cap`, default
+200), the distill call omits context entirely for that batch and
+auto-supersession is skipped for it — an oversized context blows the prompt
+budget and the model has nothing reliable to judge supersession against.
+The cap is exposed as a flag because the context block dominates each
+call's prompt, and Ollama Cloud bills by GPU-time per call: a smaller cap
+is a direct per-call cost cut at some supersession-recall cost.
+
+`--batch` groups consecutive pending chunks into one numbered-chunks call
+(the response schema gains per-fact `chunk_index` for attribution). The
+whole batch retries, fails, and gets marked as a unit; `--batch 1` sends the
+byte-identical pre-batching prompt. Batching exists for the same billing
+reason as `--context-cap`: N chunks in one call cost far less than N
+separate calls, since the shared context block is paid once per call.
 
 ### Tombstone / supersedes resolution
 

--- a/internal/distill/distill.go
+++ b/internal/distill/distill.go
@@ -23,7 +23,7 @@ import (
 )
 
 // ErrCircuitBreaker is returned by Run (wrapped, with the streak length) when
-// cfg.CircuitBreaker consecutive chunks each exhaust their retry budget and
+// cfg.CircuitBreaker consecutive batches each exhaust their retry budget and
 // still fail — a persistent condition (Ollama cloud quota/rate exhausted for
 // the day, endpoint unreachable) rather than the transient blips MaxRetries
 // already absorbs. Callers should treat it as "stop and try again later",
@@ -31,19 +31,25 @@ import (
 // so the next Run naturally resumes from where this one gave up.
 var ErrCircuitBreaker = errors.New("distill: circuit breaker tripped")
 
-// Candidate is one fact proposed by the distiller for a single chunk.
+// Candidate is one fact proposed by the distiller for a single chunk. In a
+// multi-chunk call, ChunkIndex is the 1-based position within that call's
+// chunk list, as self-reported by the model ("chunk_index" in the response
+// JSON); 0 means the model didn't say.
 type Candidate struct {
 	Subject       string
 	Predicate     string
 	Object        string
 	Confidence    float64
 	SupersedesIDs []int64
+	ChunkIndex    int
 }
 
-// Distiller extracts fact candidates from a chunk and reports availability.
+// Distiller extracts fact candidates from one or more chunks and reports
+// availability. A call carries a batch of chunk contents (len >= 1); a single
+// chunk per call is the original behavior and uses the single-chunk prompt.
 type Distiller interface {
 	Available() bool
-	Distill(ctx context.Context, chunk string, existing []internal.Fact) ([]Candidate, error)
+	Distill(ctx context.Context, chunks []string, existing []internal.Fact) ([]Candidate, error)
 }
 
 // Client is an Ollama-backed Distiller.
@@ -122,16 +128,17 @@ type distillResponse struct {
 		Predicate     string  `json:"predicate"`
 		Object        string  `json:"object"`
 		Confidence    float64 `json:"confidence"`
+		ChunkIndex    int     `json:"chunk_index"`
 		SupersedesIDs []int64 `json:"supersedes_ids"`
 	} `json:"facts"`
 }
 
-// Distill returns fact candidates extracted from chunk via POST /api/generate.
+// Distill returns fact candidates extracted from chunks via POST /api/generate.
 // The request is cancelled when ctx is done. Single attempt, no retry — a
 // failed chunk is left un-distilled for the next run, matching embed's
 // documented no-retry convention.
-func (c *Client) Distill(ctx context.Context, chunk string, existing []internal.Fact) ([]Candidate, error) {
-	prompt := buildPrompt(chunk, existing)
+func (c *Client) Distill(ctx context.Context, chunks []string, existing []internal.Fact) ([]Candidate, error) {
+	prompt := buildPrompt(chunks, existing)
 	body, _ := json.Marshal(map[string]any{
 		"model":  c.model,
 		"prompt": prompt,
@@ -175,6 +182,7 @@ func (c *Client) Distill(ctx context.Context, chunk string, existing []internal.
 			Object:        f.Object,
 			Confidence:    f.Confidence,
 			SupersedesIDs: f.SupersedesIDs,
+			ChunkIndex:    f.ChunkIndex,
 		})
 	}
 	return candidates, nil
@@ -197,14 +205,10 @@ func stripMarkdownFence(s string) string {
 	return strings.TrimSpace(s)
 }
 
-const promptTemplate = `You extract atomic, durable facts from a single Claude Code conversation
-chunk. The chunk may be in English or Ukrainian or both — extract facts in
-the language they are stated; do not translate.
-
-Return ONLY JSON: {"facts":[{"subject":"...","predicate":"...","object":"...",
-"confidence":0.0,"supersedes_ids":[]}]}
-
-Each fact is a subject-predicate-object triple about the USER, the PROJECT,
+// factExtractionRules is the instruction block shared by both prompt
+// variants: what a fact is, the confidence scale, and the supersession
+// contract. One const so the two variants cannot drift apart.
+const factExtractionRules = `Each fact is a subject-predicate-object triple about the USER, the PROJECT,
 its CODE, DECISIONS, or CONVENTIONS. Extract only durable, reusable facts —
 not transient chit-chat, not restatements of the assistant's own reasoning.
 
@@ -216,7 +220,18 @@ You are given the project's CURRENT KNOWN FACTS (id + statement). If a fact
 you extract makes one of them false or out of date (status change, reversed
 decision, corrected value about the SAME subject), put that id in
 "supersedes_ids". Only use ids from this list. If nothing is superseded, use
-an empty array. Do not supersede a fact that is merely related but still true.
+an empty array. Do not supersede a fact that is merely related but still true.`
+
+// promptTemplate is the original single-chunk prompt. A len(chunks)==1 call
+// renders exactly what every call rendered before batching existed.
+const promptTemplate = `You extract atomic, durable facts from a single Claude Code conversation
+chunk. The chunk may be in English or Ukrainian or both — extract facts in
+the language they are stated; do not translate.
+
+Return ONLY JSON: {"facts":[{"subject":"...","predicate":"...","object":"...",
+"confidence":0.0,"supersedes_ids":[]}]}
+
+` + factExtractionRules + `
 
 CURRENT KNOWN FACTS:
 %s
@@ -224,10 +239,33 @@ CURRENT KNOWN FACTS:
 CHUNK:
 %s`
 
-// buildPrompt renders promptTemplate. Kept as plain string formatting, not
-// text/template — this codebase has no templating framework and one call
-// site doesn't justify adding one.
-func buildPrompt(chunk string, existing []internal.Fact) string {
+// batchPromptTemplate extends promptTemplate to multiple numbered chunks:
+// the response schema gains per-fact chunk_index, and the CHUNK section
+// becomes a numbered CHUNKS list each fact must cite.
+const batchPromptTemplate = `You extract atomic, durable facts from numbered Claude Code conversation
+chunks. The chunks may be in English or Ukrainian or both — extract facts in
+the language they are stated; do not translate.
+
+Return ONLY JSON: {"facts":[{"subject":"...","predicate":"...","object":"...",
+"confidence":0.0,"chunk_index":1,"supersedes_ids":[]}]}
+
+Each fact must carry "chunk_index": the number of the chunk it was extracted
+from.
+
+` + factExtractionRules + `
+
+CURRENT KNOWN FACTS:
+%s
+
+CHUNKS:
+%s`
+
+// buildPrompt renders the prompt for a call over chunks. One chunk renders
+// the original single-chunk template; two or more render the numbered batch
+// template. Kept as plain string formatting, not text/template — this
+// codebase has no templating framework and two call-site branches don't
+// justify adding one.
+func buildPrompt(chunks []string, existing []internal.Fact) string {
 	var factsBlock strings.Builder
 	if len(existing) == 0 {
 		factsBlock.WriteString("(none yet)")
@@ -236,15 +274,33 @@ func buildPrompt(chunk string, existing []internal.Fact) string {
 			fmt.Fprintf(&factsBlock, " - [%d] %s | %s | %s\n", f.ID, f.Subject, f.Predicate, f.Object)
 		}
 	}
-	return fmt.Sprintf(promptTemplate, strings.TrimRight(factsBlock.String(), "\n"), chunk)
+	facts := strings.TrimRight(factsBlock.String(), "\n")
+	if len(chunks) == 1 {
+		return fmt.Sprintf(promptTemplate, facts, chunks[0])
+	}
+	var chunkBlock strings.Builder
+	for i, c := range chunks {
+		fmt.Fprintf(&chunkBlock, "[%d] %s\n\n", i+1, c)
+	}
+	return fmt.Sprintf(batchPromptTemplate, facts, strings.TrimRight(chunkBlock.String(), "\n"))
 }
 
 // Config controls a distill Run.
 type Config struct {
 	Threshold   float64 // minimum confidence to store a fact (default 0.7)
 	ContextCap  int     // max current facts to feed the distiller for supersession judgment (default 200)
-	Concurrency int     // chunks distilled in parallel; <=1 runs strictly sequential (default)
+	Concurrency int     // batches distilled in parallel; <=1 runs strictly sequential (default)
 	Limit       int     // max chunks to process this run; <=0 means no limit (process all pending)
+
+	// BatchSize is how many pending chunks share one Distill call. <=1
+	// (default) preserves the original one-chunk-per-call behavior. Batching
+	// exists because Ollama cloud bills per call, not per token: the
+	// per-call prompt is dominated by the fact-context block, so N chunks in
+	// one call cost far less than N separate calls. The retry and
+	// not-marked-until-stored semantics operate on the whole batch — a
+	// failing batch retries (and, still failing, is left for the next run)
+	// as a unit.
+	BatchSize int
 
 	// MaxRetries is the number of extra Distill attempts for a chunk whose
 	// first call errors (e.g. HTTP 429 from Ollama cloud under concurrent
@@ -301,10 +357,10 @@ type Result struct {
 	Failed          int
 }
 
-// fetchOutcome is one chunk's Distill call result, produced by a worker and
+// fetchOutcome is one batch's Distill call result, produced by a worker and
 // consumed by Run's single DB-writing loop.
 type fetchOutcome struct {
-	chunk           db.PendingFactChunk
+	batch           []db.PendingFactChunk
 	candidates      []Candidate
 	err             error
 	promptContext   []internal.Fact
@@ -315,38 +371,40 @@ type fetchOutcome struct {
 // gate deterministically in Go (the model's self-reported confidence is
 // advisory input to this hard check, not the enforcement mechanism).
 //
-// Uses context.Background() internally per pending chunk's Distill call —
+// Uses context.Background() internally per batch's Distill call —
 // distill is a manual, non-time-boxed command, explicitly exempt from
 // mine's 50s/Stop-hook budget. The passed ctx still governs overall
-// cancellation (e.g. Ctrl-C) between chunks.
+// cancellation (e.g. Ctrl-C) between batches.
 //
 // cfg.Concurrency workers fetch existing-facts context and call cli.Distill
-// (the network-bound step) in parallel; every DB write (InsertFact,
-// SupersedeFact, MarkChunkDistilled) happens sequentially in this function's
-// own goroutine as outcomes arrive, so SQLite never sees concurrent writers.
-// A side effect: "current facts" context fed to concurrently-in-flight
-// chunks may be a few facts stale relative to strictly sequential Run — the
-// same tradeoff any batched/parallel supersession pipeline makes.
+// (the network-bound step) in parallel, one call per batch of cfg.BatchSize
+// chunks; every DB write (InsertFact, SupersedeFact, MarkChunkDistilled)
+// happens sequentially in this function's own goroutine as outcomes arrive,
+// so SQLite never sees concurrent writers. A side effect: "current facts"
+// context fed to concurrently-in-flight batches may be a few facts stale
+// relative to strictly sequential Run — the same tradeoff any
+// batched/parallel supersession pipeline makes.
 //
-// A chunk whose Distill call errors is retried up to cfg.MaxRetries times
+// A batch whose Distill call errors is retried up to cfg.MaxRetries times
 // with retryBackoff between attempts, still within this same call — Ollama
 // cloud returns a plain 429 (no Retry-After) once concurrent in-flight
 // requests exceed roughly 20, and without this a high-concurrency run loses
-// a large fraction of its chunks to rate limiting instead of just slowing
-// down. A chunk still failing after the retry budget is left unmarked, same
-// as before — picked up on the next Run.
+// a large fraction of its batches to rate limiting instead of just slowing
+// down. A batch still failing after the retry budget is left unmarked (all
+// its chunks pending again), same as before — picked up on the next Run.
 //
-// If cfg.CircuitBreaker consecutive chunks each exhaust their retry budget,
-// Run stops dispatching further chunks (already-in-flight ones are allowed
-// to finish, same "graceful, not abrupt" treatment as ctx cancellation) and
-// returns ErrCircuitBreaker. External cancellation of ctx itself (e.g. the
-// caller wiring SIGINT/SIGTERM via signal.NotifyContext) is handled the same
-// way and returns ctx.Err(). Either way, every chunk marked distilled before
-// the stop is durable — nothing to "resume" beyond calling Run again later;
-// ChunksWithoutFacts will simply pick up where this call left off.
+// If cfg.CircuitBreaker consecutive batches each exhaust their retry
+// budget, Run stops dispatching further batches (already-in-flight ones are
+// allowed to finish, same "graceful, not abrupt" treatment as ctx
+// cancellation) and returns ErrCircuitBreaker. External cancellation of ctx
+// itself (e.g. the caller wiring SIGINT/SIGTERM via signal.NotifyContext)
+// is handled the same way and returns ctx.Err(). Either way, every chunk
+// marked distilled before the stop is durable — nothing to "resume" beyond
+// calling Run again later; ChunksWithoutFacts will simply pick up where
+// this call left off.
 //
 // "Consecutive" is counted in outcome-arrival order, not dispatch order —
-// under Concurrency>1 a still-in-flight chunk dispatched before a failing
+// under Concurrency>1 a still-in-flight batch dispatched before a failing
 // streak can report success afterwards and reset the count. In a genuine
 // persistent outage this only delays the trip by at most Concurrency-1
 // extra failures, never masks it (verified: Concurrency=8, CircuitBreaker=3
@@ -363,6 +421,20 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 	}
 	total := len(pending)
 
+	// Group the pending chunks into consecutive batches (in
+	// ChunksWithoutFacts order) of cfg.BatchSize; <=1 keeps the original
+	// one-chunk-per-call batches. A trailing partial batch is fine — the
+	// model just sees fewer numbered chunks that call.
+	batchSize := cfg.BatchSize
+	if batchSize < 1 {
+		batchSize = 1
+	}
+	batches := make([][]db.PendingFactChunk, 0, (total+batchSize-1)/batchSize)
+	for i := 0; i < total; i += batchSize {
+		end := min(i+batchSize, total)
+		batches = append(batches, pending[i:end])
+	}
+
 	concurrency := cfg.Concurrency
 	if concurrency < 1 {
 		concurrency = 1
@@ -376,7 +448,7 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 	runCtx, cancelRun := context.WithCancel(ctx)
 	defer cancelRun()
 
-	jobs := make(chan db.PendingFactChunk)
+	jobs := make(chan []db.PendingFactChunk)
 	outcomes := make(chan fetchOutcome)
 
 	var wg sync.WaitGroup
@@ -384,13 +456,13 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 	for i := 0; i < concurrency; i++ {
 		go func() {
 			defer wg.Done()
-			for p := range jobs {
+			for batch := range jobs {
 				if runCtx.Err() != nil {
 					return
 				}
 				existing, err := db.CurrentFacts(d, cfg.ContextCap+1)
 				if err != nil {
-					outcomes <- fetchOutcome{chunk: p, err: err}
+					outcomes <- fetchOutcome{batch: batch, err: err}
 					continue
 				}
 				// ContextCap exceeded: omit context and skip
@@ -402,6 +474,10 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 				if contextExceeded {
 					promptContext = nil
 				}
+				contents := make([]string, len(batch))
+				for i, p := range batch {
+					contents[i] = p.Content
+				}
 				// context.Background(), not runCtx: distill is exempt from
 				// the caller's deadline (see doc comment above) — runCtx
 				// only governs cancellation between chunks/retries, an
@@ -409,7 +485,7 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 				var candidates []Candidate
 				var derr error
 				for attempt := 0; ; attempt++ {
-					candidates, derr = cli.Distill(context.Background(), p.Content, promptContext)
+					candidates, derr = cli.Distill(context.Background(), contents, promptContext)
 					if derr == nil || attempt >= cfg.MaxRetries {
 						break
 					}
@@ -422,7 +498,7 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 					}
 				}
 				outcomes <- fetchOutcome{
-					chunk: p, candidates: candidates, err: derr,
+					batch: batch, candidates: candidates, err: derr,
 					promptContext: promptContext, contextExceeded: contextExceeded,
 				}
 			}
@@ -430,9 +506,9 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 	}
 	go func() {
 		defer close(jobs)
-		for _, p := range pending {
+		for _, b := range batches {
 			select {
-			case jobs <- p:
+			case jobs <- b:
 			case <-runCtx.Done():
 				return
 			}
@@ -443,16 +519,19 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 		close(outcomes)
 	}()
 
-	done := 0
+	// chunksDone tracks resolved chunks (not batches) so OnProgress's
+	// done/total stay in chunk units regardless of BatchSize.
+	chunksDone := 0
 	// consecutiveFailures and breakerTripped, like res itself, are only
 	// ever touched here in Run's own single outcome-processing goroutine —
 	// never by a worker — so no locking is needed.
 	var consecutiveFailures int
 	var breakerTripped bool
 	for oc := range outcomes {
-		done++
+		chunksDone += len(oc.batch)
 		if oc.err != nil {
-			res.Failed++ // chunk not marked — retried on the next run
+			// Batch not marked — all its chunks retried on the next run.
+			res.Failed += len(oc.batch)
 			if cfg.CircuitBreaker > 0 {
 				consecutiveFailures++
 				if consecutiveFailures >= cfg.CircuitBreaker && !breakerTripped {
@@ -461,12 +540,12 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 				}
 			}
 			if cfg.OnProgress != nil {
-				cfg.OnProgress(done, total, res)
+				cfg.OnProgress(chunksDone, total, res)
 			}
 			continue
 		}
 		consecutiveFailures = 0
-		res.ChunksDistilled++
+		res.ChunksDistilled += len(oc.batch)
 
 		allowedIDs := make(map[int64]bool, len(oc.promptContext))
 		for _, f := range oc.promptContext {
@@ -474,24 +553,34 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 		}
 
 		now := time.Now().UTC().Format(time.RFC3339)
-		// storeFailed tracks whether any candidate for this chunk hit a DB
+		// storeFailed tracks whether any candidate for this batch hit a DB
 		// error (InsertFact/SupersedeFact) rather than a confidence-gate
-		// discard. On a store failure the chunk is left unmarked so it's
-		// retried on the next run, same as a Distill call failure above —
-		// a transient DB error must not permanently drop a candidate fact.
+		// discard. On a store failure the whole batch is left unmarked so
+		// it's retried on the next run, same as a Distill call failure
+		// above — a transient DB error must not permanently drop a
+		// candidate fact.
 		var storeFailed bool
 		for _, c := range oc.candidates {
 			if c.Confidence < cfg.Threshold {
 				res.BelowThreshold++
 				continue
 			}
+			// Attribute the fact to its chunk: the model self-reports a
+			// 1-based chunk_index into the numbered list it was given. An
+			// absent or out-of-range index falls back to the first chunk
+			// of the batch — the fact is stored (not dropped) rather than
+			// lost to an off-by-one in the model's counting.
+			src := oc.batch[0]
+			if c.ChunkIndex >= 1 && c.ChunkIndex <= len(oc.batch) {
+				src = oc.batch[c.ChunkIndex-1]
+			}
 			newID, err := db.InsertFact(d, internal.Fact{
 				Subject:       c.Subject,
 				Predicate:     c.Predicate,
 				Object:        c.Object,
 				Confidence:    c.Confidence,
-				SourceChunkID: oc.chunk.ID,
-				SessionDate:   oc.chunk.SessionDate,
+				SourceChunkID: src.ID,
+				SessionDate:   src.SessionDate,
 				CreatedAt:     now,
 			})
 			if err != nil {
@@ -522,14 +611,16 @@ func Run(ctx context.Context, d *sql.DB, cli Distiller, cfg Config) (Result, err
 		}
 		if !storeFailed {
 			// A MarkChunkDistilled error here is a DB-level failure, not a
-			// content problem — the chunk is retried next run just like the
+			// content problem — the batch is retried next run just like the
 			// other failure paths above, rather than aborting the fan-out.
-			if err := db.MarkChunkDistilled(d, oc.chunk.ID, now); err != nil {
-				res.Failed++
+			for _, p := range oc.batch {
+				if err := db.MarkChunkDistilled(d, p.ID, now); err != nil {
+					res.Failed++
+				}
 			}
 		}
 		if cfg.OnProgress != nil {
-			cfg.OnProgress(done, total, res)
+			cfg.OnProgress(chunksDone, total, res)
 		}
 	}
 	if breakerTripped {

--- a/internal/distill/distill_test.go
+++ b/internal/distill/distill_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -46,7 +47,7 @@ func TestDistillParsesFacts(t *testing.T) {
 	}))
 	defer srv.Close()
 	c := NewClientURL(srv.URL, "qwen2.5:latest")
-	candidates, err := c.Distill(context.Background(), "chunk text", nil)
+	candidates, err := c.Distill(context.Background(), []string{"chunk text"}, nil)
 	if err != nil {
 		t.Fatalf("Distill: %v", err)
 	}
@@ -70,7 +71,7 @@ func TestDistillParsesFencedFacts(t *testing.T) {
 	}))
 	defer srv.Close()
 	c := NewClientURL(srv.URL, "gemma4:31b-cloud")
-	candidates, err := c.Distill(context.Background(), "chunk text", nil)
+	candidates, err := c.Distill(context.Background(), []string{"chunk text"}, nil)
 	if err != nil {
 		t.Fatalf("Distill: %v", err)
 	}
@@ -107,7 +108,7 @@ func TestDistillSurfacesHTTPStatus(t *testing.T) {
 	}))
 	defer srv.Close()
 	c := NewClientURL(srv.URL, "qwen2.5:latest")
-	_, err := c.Distill(context.Background(), "chunk", nil)
+	_, err := c.Distill(context.Background(), []string{"chunk"}, nil)
 	if err == nil {
 		t.Fatal("expected error for 500 response, got nil")
 	}
@@ -124,7 +125,7 @@ func TestDistillRespectsContextCancellation(t *testing.T) {
 	c := NewClientURL(srv.URL, "qwen2.5:latest")
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // already cancelled
-	_, err := c.Distill(ctx, "chunk", nil)
+	_, err := c.Distill(ctx, []string{"chunk"}, nil)
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
 	}
@@ -136,7 +137,7 @@ func TestDistillEmptyResponseGuard(t *testing.T) {
 	}))
 	defer srv.Close()
 	c := NewClientURL(srv.URL, "qwen2.5:latest")
-	_, err := c.Distill(context.Background(), "chunk", nil)
+	_, err := c.Distill(context.Background(), []string{"chunk"}, nil)
 	if err == nil {
 		t.Fatal("expected error for empty response, got nil")
 	}
@@ -146,15 +147,15 @@ func TestDistillEmptyResponseGuard(t *testing.T) {
 // responses, one per Distill call (matching call order).
 type stubDistiller struct {
 	avail bool
-	calls []func(chunk string, existing []internal.Fact) ([]Candidate, error)
+	calls []func(chunks []string, existing []internal.Fact) ([]Candidate, error)
 	n     int
 }
 
 func (s *stubDistiller) Available() bool { return s.avail }
-func (s *stubDistiller) Distill(_ context.Context, chunk string, existing []internal.Fact) ([]Candidate, error) {
+func (s *stubDistiller) Distill(_ context.Context, chunks []string, existing []internal.Fact) ([]Candidate, error) {
 	f := s.calls[s.n]
 	s.n++
-	return f(chunk, existing)
+	return f(chunks, existing)
 }
 
 // fixedDistiller is a concurrency-safe Distiller test double: every call
@@ -163,12 +164,12 @@ func (s *stubDistiller) Distill(_ context.Context, chunk string, existing []inte
 // meaningful (workers race to call Distill in unpredictable order).
 type fixedDistiller struct {
 	avail bool
-	fn    func(chunk string, existing []internal.Fact) ([]Candidate, error)
+	fn    func(chunks []string, existing []internal.Fact) ([]Candidate, error)
 }
 
 func (f *fixedDistiller) Available() bool { return f.avail }
-func (f *fixedDistiller) Distill(_ context.Context, chunk string, existing []internal.Fact) ([]Candidate, error) {
-	return f.fn(chunk, existing)
+func (f *fixedDistiller) Distill(_ context.Context, chunks []string, existing []internal.Fact) ([]Candidate, error) {
+	return f.fn(chunks, existing)
 }
 
 // flakyDistiller fails its first failCount calls (thread-safe via atomic
@@ -178,16 +179,16 @@ type flakyDistiller struct {
 	avail     bool
 	failCount int64
 	calls     int64
-	succeed   func(chunk string, existing []internal.Fact) ([]Candidate, error)
+	succeed   func(chunks []string, existing []internal.Fact) ([]Candidate, error)
 }
 
 func (f *flakyDistiller) Available() bool { return f.avail }
-func (f *flakyDistiller) Distill(_ context.Context, chunk string, existing []internal.Fact) ([]Candidate, error) {
+func (f *flakyDistiller) Distill(_ context.Context, chunks []string, existing []internal.Fact) ([]Candidate, error) {
 	n := atomic.AddInt64(&f.calls, 1)
 	if n <= f.failCount {
 		return nil, errors.New("simulated transient failure")
 	}
-	return f.succeed(chunk, existing)
+	return f.succeed(chunks, existing)
 }
 
 // Package-level counter, safe only because no test in this suite (or this
@@ -219,8 +220,8 @@ func openTestDB(t *testing.T) *sql.DB {
 func TestRunAppliesConfidenceGate(t *testing.T) {
 	d := openTestDB(t)
 	seedChunk(t, d, "chunk one content here", "2026-07-01")
-	cli := &stubDistiller{avail: true, calls: []func(string, []internal.Fact) ([]Candidate, error){
-		func(string, []internal.Fact) ([]Candidate, error) {
+	cli := &stubDistiller{avail: true, calls: []func([]string, []internal.Fact) ([]Candidate, error){
+		func([]string, []internal.Fact) ([]Candidate, error) {
 			return []Candidate{
 				{Subject: "s", Predicate: "p", Object: "high", Confidence: 0.9},
 				{Subject: "s", Predicate: "p", Object: "low", Confidence: 0.4},
@@ -240,8 +241,8 @@ func TestRunAppliesSupersession(t *testing.T) {
 	d := openTestDB(t)
 	// First chunk establishes a fact.
 	seedChunk(t, d, "old status chunk", "2026-07-01")
-	cli := &stubDistiller{avail: true, calls: []func(string, []internal.Fact) ([]Candidate, error){
-		func(string, []internal.Fact) ([]Candidate, error) {
+	cli := &stubDistiller{avail: true, calls: []func([]string, []internal.Fact) ([]Candidate, error){
+		func([]string, []internal.Fact) ([]Candidate, error) {
 			return []Candidate{{Subject: "project", Predicate: "status", Object: "not started", Confidence: 0.9}}, nil
 		},
 	}}
@@ -256,8 +257,8 @@ func TestRunAppliesSupersession(t *testing.T) {
 
 	// Second chunk supersedes the first, citing the id it was given.
 	seedChunk(t, d, "new status chunk", "2026-07-02")
-	cli2 := &stubDistiller{avail: true, calls: []func(string, []internal.Fact) ([]Candidate, error){
-		func(_ string, given []internal.Fact) ([]Candidate, error) {
+	cli2 := &stubDistiller{avail: true, calls: []func([]string, []internal.Fact) ([]Candidate, error){
+		func(_ []string, given []internal.Fact) ([]Candidate, error) {
 			if len(given) != 1 || given[0].ID != oldID {
 				t.Fatalf("expected context to contain old fact id %d, got %+v", oldID, given)
 			}
@@ -281,8 +282,8 @@ func TestRunAppliesSupersession(t *testing.T) {
 func TestRunMarksChunkOnZeroFacts(t *testing.T) {
 	d := openTestDB(t)
 	seedChunk(t, d, "chunk with nothing extractable", "2026-07-01")
-	cli := &stubDistiller{avail: true, calls: []func(string, []internal.Fact) ([]Candidate, error){
-		func(string, []internal.Fact) ([]Candidate, error) { return nil, nil },
+	cli := &stubDistiller{avail: true, calls: []func([]string, []internal.Fact) ([]Candidate, error){
+		func([]string, []internal.Fact) ([]Candidate, error) { return nil, nil },
 	}}
 	res, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200})
 	if err != nil {
@@ -300,8 +301,8 @@ func TestRunMarksChunkOnZeroFacts(t *testing.T) {
 func TestRunLeavesChunkOnError(t *testing.T) {
 	d := openTestDB(t)
 	seedChunk(t, d, "chunk that fails distillation", "2026-07-01")
-	cli := &stubDistiller{avail: true, calls: []func(string, []internal.Fact) ([]Candidate, error){
-		func(string, []internal.Fact) ([]Candidate, error) {
+	cli := &stubDistiller{avail: true, calls: []func([]string, []internal.Fact) ([]Candidate, error){
+		func([]string, []internal.Fact) ([]Candidate, error) {
 			return nil, context.DeadlineExceeded
 		},
 	}}
@@ -325,7 +326,7 @@ func TestRunLeavesChunkOnError(t *testing.T) {
 func TestRunRetriesOnFailureThenSucceeds(t *testing.T) {
 	d := openTestDB(t)
 	seedChunk(t, d, "chunk that succeeds on the third attempt", "2026-07-01")
-	cli := &flakyDistiller{avail: true, failCount: 2, succeed: func(string, []internal.Fact) ([]Candidate, error) {
+	cli := &flakyDistiller{avail: true, failCount: 2, succeed: func([]string, []internal.Fact) ([]Candidate, error) {
 		return []Candidate{{Subject: "s", Predicate: "p", Object: "o", Confidence: 0.9}}, nil
 	}}
 	res, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200, MaxRetries: 2})
@@ -382,8 +383,8 @@ func TestRunLeavesChunkOnInsertFactError(t *testing.T) {
 	if _, err := d.Exec(`DROP TABLE facts_fts`); err != nil {
 		t.Fatalf("drop facts_fts table: %v", err)
 	}
-	cli := &stubDistiller{avail: true, calls: []func(string, []internal.Fact) ([]Candidate, error){
-		func(string, []internal.Fact) ([]Candidate, error) {
+	cli := &stubDistiller{avail: true, calls: []func([]string, []internal.Fact) ([]Candidate, error){
+		func([]string, []internal.Fact) ([]Candidate, error) {
 			return []Candidate{{Subject: "s", Predicate: "p", Object: "o", Confidence: 0.9}}, nil
 		},
 	}}
@@ -413,8 +414,8 @@ func TestRunUsesBackgroundContextForDistillCall(t *testing.T) {
 	d := openTestDB(t)
 	seedChunk(t, d, "chunk checking context independence", "2026-07-01")
 	var gotCtx context.Context
-	cli := &stubDistiller{avail: true, calls: []func(string, []internal.Fact) ([]Candidate, error){
-		func(string, []internal.Fact) ([]Candidate, error) {
+	cli := &stubDistiller{avail: true, calls: []func([]string, []internal.Fact) ([]Candidate, error){
+		func([]string, []internal.Fact) ([]Candidate, error) {
 			return nil, nil
 		},
 	}}
@@ -437,16 +438,16 @@ type capturingDistiller struct {
 }
 
 func (c *capturingDistiller) Available() bool { return c.inner.Available() }
-func (c *capturingDistiller) Distill(ctx context.Context, chunk string, existing []internal.Fact) ([]Candidate, error) {
+func (c *capturingDistiller) Distill(ctx context.Context, chunks []string, existing []internal.Fact) ([]Candidate, error) {
 	*c.captured = ctx
-	return c.inner.Distill(ctx, chunk, existing)
+	return c.inner.Distill(ctx, chunks, existing)
 }
 
 func TestRunRejectsSupersedeIDOutsideContext(t *testing.T) {
 	d := openTestDB(t)
 	seedChunk(t, d, "chunk citing an id it was never given", "2026-07-01")
-	cli := &stubDistiller{avail: true, calls: []func(string, []internal.Fact) ([]Candidate, error){
-		func(string, []internal.Fact) ([]Candidate, error) {
+	cli := &stubDistiller{avail: true, calls: []func([]string, []internal.Fact) ([]Candidate, error){
+		func([]string, []internal.Fact) ([]Candidate, error) {
 			// existing is empty (no prior facts), yet the model claims to
 			// supersede id 999 — must be rejected, not applied blindly.
 			return []Candidate{{Subject: "s", Predicate: "p", Object: "o",
@@ -467,7 +468,7 @@ func TestRunRespectsLimit(t *testing.T) {
 	seedChunk(t, d, "chunk one", "2026-07-01")
 	seedChunk(t, d, "chunk two", "2026-07-02")
 	seedChunk(t, d, "chunk three", "2026-07-03")
-	cli := &fixedDistiller{avail: true, fn: func(string, []internal.Fact) ([]Candidate, error) {
+	cli := &fixedDistiller{avail: true, fn: func([]string, []internal.Fact) ([]Candidate, error) {
 		return nil, nil
 	}}
 	res, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200, Limit: 2})
@@ -495,7 +496,7 @@ func TestRunConcurrencyProcessesAllChunks(t *testing.T) {
 		seedChunk(t, d, "concurrent chunk", "2026-07-01")
 	}
 	var calls int64
-	cli := &fixedDistiller{avail: true, fn: func(string, []internal.Fact) ([]Candidate, error) {
+	cli := &fixedDistiller{avail: true, fn: func([]string, []internal.Fact) ([]Candidate, error) {
 		atomic.AddInt64(&calls, 1)
 		return []Candidate{{Subject: "s", Predicate: "p", Object: "o", Confidence: 0.9}}, nil
 	}}
@@ -521,7 +522,7 @@ func TestRunProgressCallback(t *testing.T) {
 	for i := 0; i < n; i++ {
 		seedChunk(t, d, "chunk", "2026-07-01")
 	}
-	cli := &fixedDistiller{avail: true, fn: func(string, []internal.Fact) ([]Candidate, error) {
+	cli := &fixedDistiller{avail: true, fn: func([]string, []internal.Fact) ([]Candidate, error) {
 		return nil, nil
 	}}
 	var mu sync.Mutex
@@ -572,7 +573,7 @@ func TestRunCtxCancellationDuringConcurrentRun(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	cli := &fixedDistiller{avail: true, fn: func(string, []internal.Fact) ([]Candidate, error) {
+	cli := &fixedDistiller{avail: true, fn: func([]string, []internal.Fact) ([]Candidate, error) {
 		time.Sleep(20 * time.Millisecond)
 		return []Candidate{{Subject: "s", Predicate: "p", Object: "o", Confidence: 0.9}}, nil
 	}}
@@ -659,7 +660,7 @@ func TestRunCircuitBreakerResetsOnSuccess(t *testing.T) {
 		seedChunk(t, d, "chunk", "2026-07-01")
 	}
 	var calls int64
-	cli := &fixedDistiller{avail: true, fn: func(string, []internal.Fact) ([]Candidate, error) {
+	cli := &fixedDistiller{avail: true, fn: func([]string, []internal.Fact) ([]Candidate, error) {
 		n := atomic.AddInt64(&calls, 1)
 		if n%3 == 0 {
 			return []Candidate{{Subject: "s", Predicate: "p", Object: "o", Confidence: 0.9}}, nil
@@ -697,5 +698,250 @@ func TestRunCircuitBreakerDisabledByDefault(t *testing.T) {
 	}
 	if res.Failed != n {
 		t.Fatalf("res.Failed = %d, want %d (every chunk attempted)", res.Failed, n)
+	}
+}
+
+// TestBuildPromptSingleChunkMatchesOriginalPrompt pins the single-chunk
+// prompt byte-for-byte: batching must not change what a one-chunk call
+// sends, so every existing deployment (BatchSize 1) keeps the exact prompt
+// its model was tuned on. Any intentional prompt change must update this
+// golden string deliberately, not drift into it.
+func TestBuildPromptSingleChunkMatchesOriginalPrompt(t *testing.T) {
+	got := buildPrompt([]string{"body text"}, []internal.Fact{
+		{ID: 7, Subject: "s", Predicate: "p", Object: "o"},
+	})
+	want := `You extract atomic, durable facts from a single Claude Code conversation
+chunk. The chunk may be in English or Ukrainian or both — extract facts in
+the language they are stated; do not translate.
+
+Return ONLY JSON: {"facts":[{"subject":"...","predicate":"...","object":"...",
+"confidence":0.0,"supersedes_ids":[]}]}
+
+Each fact is a subject-predicate-object triple about the USER, the PROJECT,
+its CODE, DECISIONS, or CONVENTIONS. Extract only durable, reusable facts —
+not transient chit-chat, not restatements of the assistant's own reasoning.
+
+Confidence: explicitly stated as current truth → 0.9+; clearly implied →
+0.5-0.8; speculation/hedged/uncertain → below 0.5. Assign honestly —
+low-confidence facts will be discarded.
+
+You are given the project's CURRENT KNOWN FACTS (id + statement). If a fact
+you extract makes one of them false or out of date (status change, reversed
+decision, corrected value about the SAME subject), put that id in
+"supersedes_ids". Only use ids from this list. If nothing is superseded, use
+an empty array. Do not supersede a fact that is merely related but still true.
+
+CURRENT KNOWN FACTS:
+ - [7] s | p | o
+
+CHUNK:
+body text`
+	if got != want {
+		t.Fatalf("single-chunk prompt drifted from the pre-batching original:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// TestBuildPromptBatchNumbersChunks verifies the multi-chunk prompt carries
+// the numbered-chunks layout and chunk_index schema the model needs for
+// per-fact attribution, and that an empty facts context renders "(none yet)".
+func TestBuildPromptBatchNumbersChunks(t *testing.T) {
+	got := buildPrompt([]string{"alpha", "beta"}, nil)
+	for _, want := range []string{
+		`"chunk_index":1`,
+		"CHUNKS:\n[1] alpha\n\n[2] beta",
+		"CURRENT KNOWN FACTS:\n(none yet)",
+		"numbered Claude Code conversation",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("batch prompt missing %q; prompt:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "CHUNK:\n") {
+		t.Fatalf("batch prompt must not use the single-chunk CHUNK: section; prompt:\n%s", got)
+	}
+}
+
+// TestDistillParsesChunkIndex verifies the client surfaces the model's
+// self-reported per-fact chunk_index so Run can attribute facts to chunks
+// within a batched call.
+func TestDistillParsesChunkIndex(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"response":"{\"facts\":[{\"subject\":\"s\",\"predicate\":\"p\",\"object\":\"o\",\"confidence\":0.9,\"chunk_index\":2,\"supersedes_ids\":[]}]}"}`))
+	}))
+	defer srv.Close()
+	c := NewClientURL(srv.URL, "qwen2.5:latest")
+	candidates, err := c.Distill(context.Background(), []string{"one", "two"}, nil)
+	if err != nil {
+		t.Fatalf("Distill: %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].ChunkIndex != 2 {
+		t.Fatalf("candidates = %+v, want one with ChunkIndex=2", candidates)
+	}
+}
+
+// TestRunBatchesChunksPerCall seeds 5 chunks and runs at BatchSize 4:
+// exactly 2 Distill calls (a full batch of 4 plus a partial 1), all 5
+// chunks marked, and every fact attributed to the chunk its chunk_index
+// names — not lumped onto the first chunk of the batch.
+func TestRunBatchesChunksPerCall(t *testing.T) {
+	d := openTestDB(t)
+	var ids []int64
+	for i := 0; i < 5; i++ {
+		ids = append(ids, seedChunk(t, d, fmt.Sprintf("chunk %d content", i), "2026-07-01"))
+	}
+	var calls int64
+	cli := &fixedDistiller{avail: true, fn: func(chunks []string, _ []internal.Fact) ([]Candidate, error) {
+		atomic.AddInt64(&calls, 1)
+		if len(chunks) != 4 && len(chunks) != 1 {
+			t.Errorf("Distill call got %d chunks, want 4 (full batch) or 1 (partial last batch)", len(chunks))
+		}
+		// Subject = the chunk's own content, unique across batches, so
+		// attribution can be asserted per chunk even though chunk indexes
+		// restart at 1 in each call.
+		cands := make([]Candidate, 0, len(chunks))
+		for i := range chunks {
+			cands = append(cands, Candidate{
+				Subject: chunks[i], Predicate: "p", Object: "o",
+				Confidence: 0.9, ChunkIndex: i + 1,
+			})
+		}
+		return cands, nil
+	}}
+	res, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200, BatchSize: 4})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := atomic.LoadInt64(&calls); got != 2 {
+		t.Fatalf("Distill called %d times, want 2 (one per batch)", got)
+	}
+	if res.ChunksDistilled != 5 || res.FactsInserted != 5 || res.Failed != 0 {
+		t.Fatalf("res = %+v, want ChunksDistilled=5 FactsInserted=5 Failed=0", res)
+	}
+	pending, err := db.ChunksWithoutFacts(d)
+	if err != nil || len(pending) != 0 {
+		t.Fatalf("pending after batched run = %+v err=%v, want none (partial batch included)", pending, err)
+	}
+	// Per-fact attribution: the fact extracted from chunk i (subject = its
+	// content) must cite that chunk's id.
+	facts, err := db.CurrentFacts(d, 10)
+	if err != nil {
+		t.Fatalf("CurrentFacts: %v", err)
+	}
+	seen := map[string]int64{}
+	for _, f := range facts {
+		seen[f.Subject] = f.SourceChunkID
+	}
+	for i, id := range ids {
+		subj := fmt.Sprintf("chunk %d content", i)
+		if seen[subj] != id {
+			t.Errorf("fact %q attributed to chunk %d, want %d", subj, seen[subj], id)
+		}
+	}
+}
+
+// TestRunBatchFailsAsUnit verifies a batch whose Distill call fails after
+// its retry budget leaves ALL its chunks unmarked (retried on the next run)
+// and counts every chunk as failed — batching must not silently drop a
+// chunk whose extraction succeeded only in a call that then errored, which
+// is why the whole batch is the unit of retry and marking.
+func TestRunBatchFailsAsUnit(t *testing.T) {
+	d := openTestDB(t)
+	for i := 0; i < 4; i++ {
+		seedChunk(t, d, "chunk in a failing batch", "2026-07-01")
+	}
+	var calls int64
+	cli := &fixedDistiller{avail: true, fn: func(_ []string, _ []internal.Fact) ([]Candidate, error) {
+		atomic.AddInt64(&calls, 1)
+		return nil, errors.New("simulated batch failure")
+	}}
+	res, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200, BatchSize: 4, MaxRetries: 1})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Failed != 4 || res.ChunksDistilled != 0 {
+		t.Fatalf("res = %+v, want Failed=4 ChunksDistilled=0", res)
+	}
+	if got := atomic.LoadInt64(&calls); got != 2 {
+		t.Fatalf("Distill called %d times, want 2 (1 initial + 1 retry for the whole batch)", got)
+	}
+	pending, err := db.ChunksWithoutFacts(d)
+	if err != nil || len(pending) != 4 {
+		t.Fatalf("pending after failed batch = %+v err=%v, want all 4 (batch retried as a unit next run)", pending, err)
+	}
+}
+
+// TestRunInvalidChunkIndexAttributedToFirstChunk covers the model's
+// chunk_index being absent (0) or out of range: the fact is stored anyway,
+// attributed to the batch's first chunk, rather than dropped or misindexed.
+func TestRunInvalidChunkIndexAttributedToFirstChunk(t *testing.T) {
+	d := openTestDB(t)
+	firstID := seedChunk(t, d, "first chunk in batch", "2026-07-01")
+	seedChunk(t, d, "second chunk in batch", "2026-07-01")
+	seedChunk(t, d, "third chunk in batch", "2026-07-01")
+	cli := &fixedDistiller{avail: true, fn: func(_ []string, _ []internal.Fact) ([]Candidate, error) {
+		return []Candidate{
+			{Subject: "absent", Predicate: "p", Object: "o", Confidence: 0.9, ChunkIndex: 0},
+			{Subject: "out-of-range", Predicate: "p", Object: "o", Confidence: 0.9, ChunkIndex: 99},
+		}, nil
+	}}
+	res, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200, BatchSize: 3})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.FactsInserted != 2 {
+		t.Fatalf("res.FactsInserted = %d, want 2 (invalid index must not drop the fact)", res.FactsInserted)
+	}
+	facts, err := db.CurrentFacts(d, 10)
+	if err != nil {
+		t.Fatalf("CurrentFacts: %v", err)
+	}
+	for _, f := range facts {
+		if f.SourceChunkID != firstID {
+			t.Errorf("fact %q attributed to chunk %d, want first chunk %d", f.Subject, f.SourceChunkID, firstID)
+		}
+	}
+}
+
+// TestRunRespectsContextCap verifies ContextCap plumbing at both edges:
+// facts at or under the cap are passed to the distiller as context, and
+// more facts than the cap disables the context entirely (the
+// contextExceeded path) rather than sending a truncated slice.
+func TestRunRespectsContextCap(t *testing.T) {
+	d := openTestDB(t)
+	// Phase 1: establish 2 live facts via a normal run.
+	for i := 0; i < 2; i++ {
+		seedChunk(t, d, fmt.Sprintf("fact-bearing chunk %d", i), "2026-07-01")
+	}
+	store := &fixedDistiller{avail: true, fn: func(chunks []string, _ []internal.Fact) ([]Candidate, error) {
+		return []Candidate{{Subject: chunks[0], Predicate: "p", Object: "o", Confidence: 0.9}}, nil
+	}}
+	if _, err := Run(context.Background(), d, store, Config{Threshold: 0.7, ContextCap: 200}); err != nil {
+		t.Fatalf("Run seed: %v", err)
+	}
+
+	// Phase 2: a new chunk at ContextCap 2 — the 2 existing facts fit, so
+	// the distiller must receive all of them.
+	seedChunk(t, d, "chunk at cap", "2026-07-02")
+	atCap := &fixedDistiller{avail: true, fn: func(_ []string, given []internal.Fact) ([]Candidate, error) {
+		if len(given) != 2 {
+			t.Errorf("existing context = %d facts, want 2 (ContextCap 2 with 2 live facts)", len(given))
+		}
+		return nil, nil
+	}}
+	if _, err := Run(context.Background(), d, atCap, Config{Threshold: 0.7, ContextCap: 2}); err != nil {
+		t.Fatalf("Run at cap: %v", err)
+	}
+
+	// Phase 3: ContextCap 1 against 2+ live facts — exceeded, so the
+	// distiller must get no context at all (and supersession is skipped).
+	seedChunk(t, d, "chunk over cap", "2026-07-02")
+	overCap := &fixedDistiller{avail: true, fn: func(_ []string, given []internal.Fact) ([]Candidate, error) {
+		if given != nil {
+			t.Errorf("existing context = %d facts, want none (ContextCap 1 with 2+ live facts)", len(given))
+		}
+		return nil, nil
+	}}
+	if _, err := Run(context.Background(), d, overCap, Config{Threshold: 0.7, ContextCap: 1}); err != nil {
+		t.Fatalf("Run over cap: %v", err)
 	}
 }

--- a/internal/distill/distill_test.go
+++ b/internal/distill/distill_test.go
@@ -839,6 +839,46 @@ func TestRunBatchesChunksPerCall(t *testing.T) {
 	}
 }
 
+// TestRunLeavesBatchOnInsertFactError is the batched counterpart of
+// TestRunLeavesChunkOnInsertFactError: a DB-level failure storing any
+// candidate fact in a batch must leave the WHOLE batch unmarked, so every
+// chunk in it is retried on the next run — the batch is the unit of
+// marking, and a transient DB error on one candidate must not silently
+// mark its (equally unstored) siblings as done.
+func TestRunLeavesBatchOnInsertFactError(t *testing.T) {
+	d := openTestDB(t)
+	for i := 0; i < 4; i++ {
+		seedChunk(t, d, "chunk whose fact fails to store", "2026-07-01")
+	}
+	// Drop facts_fts (the trigger target for INSERT INTO facts) so
+	// InsertFact fails deterministically inside Run — same fault-injection
+	// trick as TestRunLeavesChunkOnInsertFactError, which explains why it
+	// works without touching production code.
+	if _, err := d.Exec(`DROP TABLE facts_fts`); err != nil {
+		t.Fatalf("drop facts_fts table: %v", err)
+	}
+	cli := &fixedDistiller{avail: true, fn: func(chunks []string, _ []internal.Fact) ([]Candidate, error) {
+		if len(chunks) != 4 {
+			t.Errorf("Distill call got %d chunks, want the full batch of 4", len(chunks))
+		}
+		return []Candidate{{Subject: "s", Predicate: "p", Object: "o", Confidence: 0.9}}, nil
+	}}
+	res, err := Run(context.Background(), d, cli, Config{Threshold: 0.7, ContextCap: 200, BatchSize: 4})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.FactsInserted != 0 {
+		t.Fatalf("res.FactsInserted = %d, want 0", res.FactsInserted)
+	}
+	if res.Failed < 1 {
+		t.Fatalf("res.Failed = %d, want >= 1 (the failed insert must be counted)", res.Failed)
+	}
+	pending, err := db.ChunksWithoutFacts(d)
+	if err != nil || len(pending) != 4 {
+		t.Fatalf("pending after InsertFact failure in batch = %+v err=%v, want all 4 (whole batch retried, not just the failing candidate)", pending, err)
+	}
+}
+
 // TestRunBatchFailsAsUnit verifies a batch whose Distill call fails after
 // its retry budget leaves ALL its chunks unmarked (retried on the next run)
 // and counts every chunk as failed — batching must not silently drop a


### PR DESCRIPTION
## Context

The nightly session-maintain distill runs across 8 projects hit **80% of the weekly Ollama Pro quota at peak** — a call-volume problem, not per-call price (deepseek-v4-flash is fairly priced per call, `expens` ~0.88–0.95). Two independent multipliers:

1. **Unit of billing = one chunk = one Ollama cloud call** (`distill.Run` → `cli.Distill` per pending chunk). Peak inflow ~5468 calls/day.
2. **The per-call prompt is dominated by the facts-context block** — hardcoded `ContextCap: 200` ≈ 14KB vs an average ~470-char chunk (~30×). It's also a recency slice of 96K–100K live facts (0.2%), so supersession against the whole base is structurally impossible anyway.

Cost evidence that prompt size drives per-call price: trivial prompt = 0.000114%/call vs real distill call (~3.7K tokens, mostly context) = 0.00209%/call (18×).

## Changes

Two flags, both **defaulting to current behavior** (runtime-dialable without redeploy):

- **`--context-cap`** (default 200, previously hardcoded in `main.go`): the facts-context block is now a tunable cost/quality dial.
- **`--batch N`** (default 1 = original per-chunk behavior): groups N pending chunks into one numbered-chunks Distill call:
  - prompt gets numbered `CHUNKS:` list; response schema gains per-fact `chunk_index` for `SourceChunkID` attribution (absent/out-of-range index → attributed to the batch's first chunk, fact is stored not dropped);
  - the batch retries, fails, and gets marked distilled **as a unit** (same resume semantics, bigger unit);
  - a `--batch 1` call renders the **byte-identical pre-batching prompt** — golden-tested (`TestBuildPromptSingleChunkMatchesOriginalPrompt`).

`Result` counts stay per-chunk; `OnProgress` done/total stay in chunk units; circuit-breaker streak is now counted per batch (doc updated).

Expected impact at `--context-cap 30 --batch 4`: per-call ~2–3× cheaper, call count ÷4 → peak-week quota 80% → ~10–15%. The hook-side flag flip lands separately in `~/wrk/common` after this binary is deployed.

## Tests

- `TestBuildPromptSingleChunkMatchesOriginalPrompt` — golden byte-identity of the single-chunk prompt
- `TestBuildPromptBatchNumbersChunks` — numbered layout + `chunk_index` schema
- `TestDistillParsesChunkIndex` — client surfaces the model's `chunk_index`
- `TestRunBatchesChunksPerCall` — 5 chunks @ batch 4 → 2 calls, per-fact attribution, partial last batch
- `TestRunBatchFailsAsUnit` — failed batch leaves all chunks unmarked, counts all as failed
- `TestRunInvalidChunkIndexAttributedToFirstChunk`
- `TestRunRespectsContextCap` — at-cap passes context, over-cap disables it (contextExceeded path)

Full suite: 114 tests pass, `-race` clean.

Docs updated: CHANGELOG (Unreleased), README, docs/architecture.md (flow diagram + safeguards), CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)