### PR TITLE
docs: expand --context-cap/--batch examples (cost dials)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,9 @@ session-indexer mine    <jsonl-path> --db <path>        # parse JSONL → SQLite
 session-indexer search  <query>      --db <path> [--limit N] [--json]
 session-indexer embed                --db <path>        # backfill missing embeddings
 session-indexer stats                --db <path>        # sessions, chunks, facts, pending, DB size
-session-indexer distill              --db <path> [--threshold 0.7]   # LLM-extract facts, manual, no deadline
+session-indexer distill              --db <path> [--threshold 0.7] [--context-cap 200] [--batch 1]
+                                                                    # LLM-extract facts, manual, no deadline;
+                                                                    # context-cap/batch are Ollama cost dials (see Facts Layer)
 session-indexer facts search/list/get/related/supersede --db <path>  # query the facts layer
 session-indexer sessions             --db <path> [--by-session]      # roll up by day (default) or session_id
 session-indexer list                 --db <path> [--limit N] [--since D] [--until D] [--role R] [--session ID]

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ session-indexer distill --db .claude/sessions.db \
     --concurrency 4 --context-cap 30 --batch 4
 # → distill: 8/8 chunks (81 facts, 0 below threshold, 0 failed) [2m55s]
 #   Distilled 8 chunks: 81 facts stored, 0 below threshold, 0 superseded
-# (8 chunks consumed in 2 Ollama calls — a full batch of 4 plus a partial 1)
+# (8 chunks consumed in 2 Ollama calls — two full batches of 4)
 
 # Smoke-test the dials on a few chunks before committing to them:
 session-indexer distill --db .claude/sessions.db --context-cap 30 --batch 4 --limit 8

--- a/README.md
+++ b/README.md
@@ -145,12 +145,6 @@ safeguards).
 session-indexer distill --db .claude/sessions.db --threshold 0.7
 # → Distilled 12 chunks: 5 facts stored, 3 below threshold, 1 superseded
 
-# Cost dials for Ollama Cloud (billed by GPU-time per call, not per token):
-# the facts-context block dominates each prompt, and one call per chunk
-# multiplies fast. Smaller context + batched chunks ≈ N× fewer, cheaper
-# calls; both default to the original behavior (200 / 1).
-session-indexer distill --db .claude/sessions.db --context-cap 30 --batch 4
-
 # Query
 session-indexer facts search "implementation status" --db .claude/sessions.db
 # → [7] session-indexer | has | 33 merged PRs (confidence 0.92)
@@ -163,6 +157,48 @@ session-indexer facts related 7 --db .claude/sessions.db
 # Manual override (audit/backstop — distill already judges supersession automatically)
 session-indexer facts supersede 9 7 --db .claude/sessions.db
 ```
+
+#### Cost dials — `--context-cap` and `--batch`
+
+Ollama Cloud bills by **GPU-time per call**, not per token, and the default
+distill prompt fights both halves of that:
+
+- every call re-sends a `CURRENT KNOWN FACTS` context block — at the default
+  cap of 200 facts it's ~14KB, roughly **30× the average ~470-char chunk**
+  it's there to judge supersession against;
+- each pending chunk is its own call, so a heavy coding day across several
+  projects multiplies into thousands of billable calls.
+
+Two flags address the two multipliers. Both default to the original
+behavior, so nothing changes unless you opt in:
+
+| Flag | Default | What it does | Effect |
+|------|---------|--------------|--------|
+| `--context-cap` | 200 | max current facts fed to the model for supersession judgment | smaller cap = smaller prompt = cheaper per call |
+| `--batch` | 1 | pending chunks per Ollama call (numbered-chunks prompt, per-fact `chunk_index` attribution) | batch N ≈ N× fewer calls |
+
+```bash
+# The nightly scheduled-maintenance invocation (what session-maintain.sh runs):
+session-indexer distill --db .claude/sessions.db \
+    --concurrency 4 --context-cap 30 --batch 4
+# → distill: 8/8 chunks (81 facts, 0 below threshold, 0 failed) [2m55s]
+#   Distilled 8 chunks: 81 facts stored, 0 below threshold, 0 superseded
+# (8 chunks consumed in 2 Ollama calls — a full batch of 4 plus a partial 1)
+
+# Smoke-test the dials on a few chunks before committing to them:
+session-indexer distill --db .claude/sessions.db --context-cap 30 --batch 4 --limit 8
+```
+
+A batch retries, fails, and gets marked distilled **as a unit** — the whole
+batch is left pending if its call errors or a fact insert fails, so nothing
+is silently dropped and the next run picks it up. A `--batch 1` call sends
+the byte-identical pre-batching prompt.
+
+**Dialing back:** if distilled-fact quality regresses (supersession misses on
+older facts, garbage/noisy facts), move `--batch` toward 1 and `--context-cap`
+toward 200; the defaults are exactly the pre-flag behavior. The 30/4
+combination above cut a measured peak of 80% of a weekly Ollama Pro quota
+(call volume, not per-call price) to a modeled ~10–15%.
 
 ## Browsing without a query
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -217,6 +217,8 @@ outdated statement never disappears on its own.
 **Flow:**
 1. Periodically (or before shipping a batch of sessions), run:
    `session-indexer distill --db .claude/sessions.db --threshold 0.7`
+   (scheduled multi-project runs add the Ollama cost dials
+   `--context-cap 30 --batch 4` — see README's "Cost dials")
 2. The LLM call extracts subject-predicate-object facts from newly-mined
    chunks and judges supersession against currently-valid facts about the
    same subject — a corrected/updated statement auto-tombstones the fact
@@ -242,9 +244,11 @@ This is the concrete gap the facts layer exists to close — see
 contradictory facts about the same subject as both "current."
 
 **Trigger:** `distill`'s automatic supersession judgment is bounded by
-`ContextCap` (200) and by whatever the model actually noticed in a given
-chunk — it can miss a contradiction the LLM didn't recognize as the same
-subject, or one that arose in two mine runs distilled far apart in time.
+`--context-cap` (default 200) and by whatever the model actually noticed in
+a given chunk — it can miss a contradiction the LLM didn't recognize as the
+same subject, or one that arose in two mine runs distilled far apart in
+time. Runs that lower the cap for cost (e.g. `--context-cap 30`) narrow the
+window further, making this manual backstop proportionally more relevant.
 
 **Flow:**
 1. `session-indexer facts search "<subject>" --db .claude/sessions.db


### PR DESCRIPTION
Follow-up to PR #71: fuller documentation examples for the distill cost dials.

- **README** — new "Cost dials — `--context-cap` and `--batch`" subsection: Ollama per-call billing rationale (200-fact context block ~14KB vs ~470-char chunk), flags table, `session-maintain.sh` invocation with real measured output (`--limit 8` smoke run: 2 calls, 81 facts, 0 failed), batch-as-unit semantics, byte-identical `--batch 1` note, dial-back guidance (peak-week model 80% → ~10-15%).
- **CLAUDE.md** — distill quick-reference line now shows both flags with a pointer to the Facts Layer section.
- **docs/use-cases.md** — UC-11 notes the scheduled-run dials; UC-12 explains how a lowered `--context-cap` narrows the supersession window, making the manual backstop proportionally more relevant.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)