### PR TITLE
skills: sync M1+M2 (curate-minions + lib/rest.sh)

### DIFF
--- a/.claude/skills/curate-minions/SKILL.md
+++ b/.claude/skills/curate-minions/SKILL.md
@@ -48,9 +48,14 @@ is a direct implementation of that section.
 ```bash
 SLUG=$(basename "$(git rev-parse --show-toplevel)")
 WEEK="${1:-latest}"
-REPORTS_DIR=~/wrk/common/reports/minions/"$SLUG"
+REPORTS_DIR="$HOME/wrk/common/reports/minions/$SLUG"
 if [[ "$WEEK" == "latest" ]]; then
-  REPORT=$(ls -1t "$REPORTS_DIR"/2026-W*.md 2>/dev/null | head -1)
+  # Robust selector: handles spaces/specials in path and filename.
+  # Report names are ISO-week tags + .md (no spaces by construction),
+  # but find + mtime-sort keeps the intent explicit if naming changes.
+  REPORT=$(find "$REPORTS_DIR" -maxdepth 1 -type f -name '2026-W*.md' \
+           -printf '%T@ %p\n' 2>/dev/null \
+           | sort -rn | head -1 | cut -d' ' -f2-)
 else
   REPORT="$REPORTS_DIR/$WEEK.md"
 fi

--- a/.claude/skills/lib/rest.sh
+++ b/.claude/skills/lib/rest.sh
@@ -141,17 +141,22 @@ chat_payload_system() {
 # Optional 5th arg: num_predict cap, Ollama branch only (default 4000).
 chat_payload_system_no_think() {
   case "$1" in
-    openrouter) openrouter_payload_system_no_think "$2" "$3" "$4" ;;
-    *)          ollama_payload_system_no_think      "$2" "$3" "$4" "$5" ;;
+    openrouter)    openrouter_payload_system_no_think "$2" "$3" "$4" ;;
+    openai_compat) openrouter_payload_system_no_think "$2" "$3" "$4" ;;
+    *)             ollama_payload_system_no_think      "$2" "$3" "$4" "$5" ;;
   esac
 }
 
 # Extract assistant content from a raw API response.
 # Usage: CONTENT=$(chat_content "$PROVIDER" "$RESPONSE")
+# Provider values:
+#   - "openrouter"    — /api/v1/chat/completions (OpenAI-compat)
+#   - "openai_compat" — same as "openrouter" (alias, more explicit at call site)
+#   - anything else   — native Ollama /api/chat
 chat_content() {
   case "$1" in
-    openrouter) openrouter_content "$2" ;;
-    *)          ollama_content     "$2" ;;
+    openrouter|openai_compat) openrouter_content "$2" ;;
+    *)                        ollama_content     "$2" ;;
   esac
 }
 

--- a/.claude/skills/lib/rest.sh
+++ b/.claude/skills/lib/rest.sh
@@ -162,17 +162,21 @@ chat_content() {
 
 # Extract token counts from a response.
 # Returns "PROMPT_TOKENS COMPLETION_TOKENS" (space-separated).
-# Ollama responses return "null null" (no token data in /api/chat).
+# Ollama native responses return "null null" (no token data in /api/chat).
+# OpenAI-compat responses (openrouter, openai_compat) DO return .usage.
 # Usage: read pt ct < <(chat_tokens "$PROVIDER" "$RESPONSE")
 chat_tokens() {
-  if [ "$1" = "openrouter" ]; then
-    local p c
-    p=$(printf '%s' "$2" | jq -r '.usage.prompt_tokens     // empty' 2>/dev/null)
-    c=$(printf '%s' "$2" | jq -r '.usage.completion_tokens // empty' 2>/dev/null)
-    printf '%s %s' "${p:-null}" "${c:-null}"
-  else
-    printf 'null null'
-  fi
+  case "$1" in
+    openrouter|openai_compat)
+      local p c
+      p=$(printf '%s' "$2" | jq -r '.usage.prompt_tokens     // empty' 2>/dev/null)
+      c=$(printf '%s' "$2" | jq -r '.usage.completion_tokens // empty' 2>/dev/null)
+      printf '%s %s' "${p:-null}" "${c:-null}"
+      ;;
+    *)
+      printf 'null null'
+      ;;
+  esac
 }
 
 # Convenience: POST + extract content in a single call.


### PR DESCRIPTION
Manual sync of two findings from `~/wrk/common/reports/dreaming/2026-W36.md` (added 2026-09-06 in the manual-additions section).

**M1** (`curate-minions/SKILL.md:48-56`): replace `ls -1t` + unquoted vars with `find` + mtime-sort + quoted expansion. Robust against spaces in path/filename. ISO-week tags can't contain spaces by construction, but explicit selector beats brittle.

**M2** (`lib/rest.sh`): add `openai_compat` alias to `chat_content` and `chat_payload_system_no_think`. This repo's fix-review hits Ollama native (`/api/chat`) — the alias doesn't change anything here, but the sync keeps the per-project fork aligned with canonical so future providers can be added in one place.

Both files are deployed copies of `~/wrk/common/.claude/skills/` canonical source (same convention as `fix-review`).