### PR TITLE
dreaming: add weekly dreaming pass

### DIFF
--- a/.claude/dreaming/dreaming-prompt.md
+++ b/.claude/dreaming/dreaming-prompt.md
@@ -8,8 +8,9 @@ anything.
 
 - **session-indexer** — single Go binary, semantic search over Claude
   Code JSONL session transcripts. No daemon, no shared state between
-  projects, pure Go/no CGO. Six subcommands (`mine`, `search`, `embed`,
-  `stats`, `distill`, `facts`, `sessions`, `list`, `show`).
+  projects, pure Go/no CGO. Subcommands: `mine`, `search`, `embed`,
+  `stats`, `distill`, `facts` (with its own `search`/`list`/`get`/
+  `related`/`supersede` child verbs), `sessions`, `list`, `show`.
 - Deployed and actively maintained via systemd across 8+ projects
   (`~/wrk/{common,projects/*/*,freelance/*/*}`) — this dreaming pass
   covers only **this repo's own code and docs**, not the deployed

--- a/.claude/dreaming/dreaming-prompt.md
+++ b/.claude/dreaming/dreaming-prompt.md
@@ -1,0 +1,117 @@
+You are doing a **dreaming pass** for the **session-indexer** project —
+async, scheduled curation of project context. This is sleep-time
+consolidation: review what accumulated since last pass, identify
+patterns, suggest curation. Read-only — output a report, don't modify
+anything.
+
+## Project context
+
+- **session-indexer** — single Go binary, semantic search over Claude
+  Code JSONL session transcripts. No daemon, no shared state between
+  projects, pure Go/no CGO. Six subcommands (`mine`, `search`, `embed`,
+  `stats`, `distill`, `facts`, `sessions`, `list`, `show`).
+- Deployed and actively maintained via systemd across 8+ projects
+  (`~/wrk/{common,projects/*/*,freelance/*/*}`) — this dreaming pass
+  covers only **this repo's own code and docs**, not the deployed
+  instances.
+- Workflow: `/ship` (issue → implement → `/fix-review` → merge → close)
+  — no `/backlog` step here; issues are created directly (`gh issue
+  create` or manually) and `/ship <issue-number>` picks them up.
+- "Before Any Commit" convention: a branch with an already-merged PR is
+  stale — never commit onto it directly, branch fresh from `main`
+  instead (see `CLAUDE.md`).
+
+## Targets
+
+| Path | What to look for |
+|------|-------------------|
+| `CLAUDE.md` "Key Constraints" | Recent commits that may violate: pure-Go/no-CGO, the Go 1.26.6+ patch pin (CVE-driven — check `go.mod`'s `go` directive hasn't regressed to an unpinned/older patch), the 60s Stop-hook budget (50s internal deadline), per-project isolation (no cross-project reads/writes) |
+| `docs/architecture.md` | Stale description of the Facts Layer / storage schema / search fallback logic vs. current `internal/` code |
+| `internal/db/schema.sql` vs `internal/types.go` | Schema drift — a column that changed without inline comments in both, or `schema_version` not bumped when it should have been |
+| Recent PR review comments | Recurring `/fix-review` themes across merged PRs |
+| `.claude/skills/` | Large roster (`curate-minions`, `debug`, `doubt-driven-development`, `find-bugs`, `fix-review`, `grill-me`, `housekeeping`, `improve`, `revival`, `self-learn`, `ship`) — flag any two that now read as overlapping |
+| `git log --since="30 days ago"` | Commits onto a branch that already had a merged PR (the exact anti-pattern `CLAUDE.md`'s "Before Any Commit" section exists to prevent) |
+| `internal/distill/` | Any change to the confidence gate, supersession logic, or `--context-cap`/`--batch` defaults not reflected in `CLAUDE.md`'s Facts Layer section |
+
+## What to find
+
+### 1. Key-Constraints violations
+
+For each of the 5 bullets in `CLAUDE.md`'s "Key Constraints", search
+recent commits (`git log --since="30 days ago" -p`) for anything that
+plausibly violates it:
+- CGO reintroduced (`import "C"`, a non-`modernc.org/sqlite` driver).
+- `go.mod`'s `go` directive dropped below `1.26.6` or the comment
+  explaining the patch pin was removed without justification.
+- A new code path in `mine`/hook integration that could exceed the 60s
+  budget (no context deadline, an unbounded loop, a synchronous
+  network call without a timeout).
+- Any query or file path that isn't scoped to `--db <path>` (a
+  cross-project leak).
+
+### 2. Architecture/schema drift
+
+Spot-check `docs/architecture.md`'s Facts Layer description (confidence
+gate, supersession, tombstone-via-`until`) against `internal/distill/
+distill.go` and `internal/facts/facts.go`. Flag anything the doc claims
+that the code no longer does, or vice versa. Same check for
+`internal/db/schema.sql` vs. `internal/types.go`'s row structs.
+
+### 3. Recurring `/fix-review` themes
+
+`gh pr list --state merged --limit 20` + `gh pr view N --json comments`.
+A theme repeating 3+ times is a candidate for a new `CLAUDE.md`
+convention or a `self-learn` pattern entry.
+
+### 4. Skill roster overlap
+
+Read `.claude/skills/*/SKILL.md` frontmatter descriptions — do
+`debug`/`doubt-driven-development`/`find-bugs`/`improve`/`revival`
+still carve out genuinely distinct territory, or has usage converged
+on 1-2 of them with the rest going stale?
+
+### 5. Stale-branch commit anti-pattern
+
+`git log --all --since="30 days ago"` — for each branch with commits,
+check `gh pr list --state merged --search "head:<branch>"`. Flag any
+branch that received a commit *after* its PR was already merged (the
+exact mistake `CLAUDE.md`'s "Before Any Commit" section documents a
+real past incident about).
+
+## Report format
+
+```markdown
+# session-indexer dreaming — <ISO week>
+
+## TL;DR
+<3-5 bullet summary>
+
+## 1. Key-Constraints violations
+### a) <finding>
+- Confidence: high|medium|low
+- Evidence: <file:line, commit sha>
+- Suggest: <action>
+
+## 2. Architecture/schema drift
+...
+
+## 3. Recurring /fix-review themes
+...
+
+## 4. Skill roster overlap
+...
+
+## 5. Stale-branch commit anti-pattern
+...
+
+## 6. Open questions
+<what you couldn't verify from a read-only pass>
+```
+
+Confidence levels: **high** = directly verified against a specific
+file/commit; **medium** = pattern observed but not exhaustively
+checked; **low** = a hunch worth someone's attention, not a confirmed
+finding. Don't fabricate evidence — say "couldn't verify" rather than
+guess. This project is deployed to 8+ other projects via systemd — a
+false "Key Constraints violation" claim wastes review time on
+something that could break production maintenance across all of them.

--- a/.claude/dreaming/dreaming.sh
+++ b/.claude/dreaming/dreaming.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# session-indexer project dreaming pass.
+#
+# Purpose: scheduled (weekly) curation of THIS project only — read-only,
+# outputs a report. Scoped to session-indexer alone (never cross-mines other
+# projects).
+#
+# Schedule: systemd user timer (Sun, spread after the other dreaming
+# timers — see ~/wrk/common/dreaming/HOW-TO-APPLY.md; Persistent=true
+# catches up at next login if the machine was off).
+
+set -euo pipefail
+
+# Ensure claude/gh/jq are reachable when invoked from a minimal systemd env
+export PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+# Route claude-code through Ollama (localhost:11434, Device Key auth).
+# Avoids Anthropic weekly limits — see ~/wrk/common/dreaming/dreaming.sh
+# for the rationale and env-vars justification.
+export ANTHROPIC_AUTH_TOKEN=ollama
+export ANTHROPIC_API_KEY=""
+export ANTHROPIC_BASE_URL=http://localhost:11434
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"  # .claude/dreaming -> project root
+REPORTS_DIR="$SCRIPT_DIR/reports"
+PROMPT_FILE="$SCRIPT_DIR/dreaming-prompt.md"
+WEEK="$(date +%Y-W%V)"
+REPORT="$REPORTS_DIR/$WEEK.md"
+LOG="$REPORTS_DIR/.dreaming.log"
+
+mkdir -p "$REPORTS_DIR"
+
+if [[ ! -f "$PROMPT_FILE" ]]; then
+  echo "[dreaming] missing prompt file: $PROMPT_FILE" >&2
+  exit 1
+fi
+
+if [[ ! -d "$PROJECT_DIR/.git" ]]; then
+  echo "[dreaming] not a git repo: $PROJECT_DIR" >&2
+  exit 1
+fi
+
+echo "[$(date -Iseconds)] session-indexer dreaming pass started" >> "$LOG"
+
+cd "$PROJECT_DIR"
+
+PROMPT="$(cat "$PROMPT_FILE")
+Today is $(date -I).
+Current branch: $(git rev-parse --abbrev-ref HEAD).
+Project root: $PROJECT_DIR.
+Write the report to stdout."
+
+echo "$PROMPT" | claude \
+  --print \
+  --model minimax-m3:cloud \
+  --fallback-model kimi-k2.7-code:cloud \
+  --allowed-tools "Read,Glob,Grep,Bash(ls:*),Bash(cat:*),Bash(wc:*),Bash(stat:*),Bash(find:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git rev-parse:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh issue list:*),Bash(awk:*),Bash(sort:*),Bash(uniq:*)" \
+  > "$REPORT" 2>> "$LOG"
+
+EXIT=$?
+echo "[$(date -Iseconds)] session-indexer dreaming finished (exit=$EXIT, report=$REPORT)" >> "$LOG"
+
+if [[ $EXIT -ne 0 ]]; then
+  echo "[dreaming] non-zero exit; check $LOG" >&2
+  exit "$EXIT"
+fi
+
+SIZE=$(wc -c < "$REPORT")
+if [[ "$SIZE" -lt 500 ]]; then
+  echo "[dreaming] WARNING: report suspiciously small ($SIZE bytes); check $REPORT" >&2
+fi
+
+echo "[dreaming] OK: $REPORT ($SIZE bytes)"

--- a/.claude/dreaming/dreaming.sh
+++ b/.claude/dreaming/dreaming.sh
@@ -51,14 +51,20 @@ Current branch: $(git rev-parse --abbrev-ref HEAD).
 Project root: $PROJECT_DIR.
 Write the report to stdout."
 
-echo "$PROMPT" | claude \
+# `if` guards the pipeline so `set -e` doesn't abort the script right
+# here on a non-zero claude exit — a bare `cmd; EXIT=$?` line under
+# errexit never reaches the EXIT=$? assignment; the whole error-handling
+# block below it becomes dead code exactly when it's needed.
+if echo "$PROMPT" | claude \
   --print \
   --model minimax-m3:cloud \
   --fallback-model kimi-k2.7-code:cloud \
   --allowed-tools "Read,Glob,Grep,Bash(ls:*),Bash(cat:*),Bash(wc:*),Bash(stat:*),Bash(find:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git rev-parse:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh issue list:*),Bash(awk:*),Bash(sort:*),Bash(uniq:*)" \
-  > "$REPORT" 2>> "$LOG"
-
-EXIT=$?
+  > "$REPORT" 2>> "$LOG"; then
+  EXIT=0
+else
+  EXIT=$?
+fi
 echo "[$(date -Iseconds)] session-indexer dreaming finished (exit=$EXIT, report=$REPORT)" >> "$LOG"
 
 if [[ $EXIT -ne 0 ]]; then

--- a/.claude/skills/apply-dreaming/SKILL.md
+++ b/.claude/skills/apply-dreaming/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: apply-dreaming
+description: "Read the latest session-indexer dreaming report and
+  apply high-confidence findings. Routes constraint/architecture/code
+  changes through a GitHub issue -> /ship (no /backlog step in this
+  project). Direct branch+PR only for tooling scripts that don't
+  touch CLAUDE.md's Key Constraints. Annotates report with
+  [applied YYYY-MM-DD] markers."
+user-invocable: true
+argument-hint: "[week|latest]"
+---
+
+# /apply-dreaming (session-indexer)
+
+Walks each dreaming-report finding interactively and leaves an audit
+trail (`[applied YYYY-MM-DD]` / `[planned …]` / `[skipped …]` markers
+appended to the report).
+
+## When to invoke
+
+- Monday morning after the Sunday cron-run produced a fresh report.
+- Or any time after a manual `.claude/dreaming/dreaming.sh` run.
+- Or `/apply-dreaming` (with optional `latest` or `2026-W##` argument).
+
+## Inputs
+
+- Optional argument: `latest` (default) or `YYYY-W##`.
+- Project root: `~/wrk/projects/session-indexer/session-indexer/`.
+
+## Steps
+
+### 1. Locate report
+
+```bash
+WEEK="${1:-latest}"
+DIR=".claude/dreaming/reports"
+if [[ "$WEEK" == "latest" ]]; then
+  REPORT=$(find "$DIR" -maxdepth 1 -type f -name '[0-9][0-9][0-9][0-9]-W*.md' \
+           -printf '%T@ %p\n' 2>/dev/null \
+           | sort -rn | head -1 | cut -d' ' -f2-)
+else
+  REPORT="$DIR/$WEEK.md"
+fi
+```
+
+### 2. Parse into structured items
+
+Read REPORT. For each numbered sub-item under a section, extract:
+
+- `id`, `title`, `confidence` (high/medium/low)
+- `evidence` — file:line / commit sha
+- `suggestion`
+- `category` — infer from the suggestion:
+  - **any Key Constraints violation** (CGO, Go patch pin, 60s budget,
+    per-project isolation) → `constraint-fix` — this project is
+    deployed via systemd across 8+ other projects; treat as
+    highest-priority regardless of stated confidence
+  - "update `docs/architecture.md`" / schema drift → `update-docs`
+  - "code change / fix drift / implement" → `code-change`
+  - "merge skills / new convention" → `update-tooling`
+  - "stale-branch commit" → `branch-hygiene`
+  - else → `other`
+
+**Confidence inheritance.** If a sub-item has no explicit `confidence`
+field, inherit it from the enclosing section. Default `medium` only
+when neither declares one.
+
+**Idempotency — skip already-marked items.** If the next non-blank
+line after an item starts with `> [applied …]`, `> [planned …]`,
+`> [skipped …]`, or `> [manual-review-required …]`, skip it silently.
+The report is appended to (never rewritten) on each pass. Print a
+summary at the start: `2026-W##: M new items (N already-processed
+skipped)`.
+
+### 3. Show TL;DR + counts
+
+```
+2026-W##: N items (X high, Y medium, Z low)
+TL;DR: ...
+Process all? [y/select/skip-low/abort]
+```
+
+### 4. Triage walk
+
+Iterate `high → medium → low`, but **surface any `constraint-fix` item
+first regardless of its stated confidence** — this binary runs inside
+other projects' Stop hooks; a regression here is a multi-project
+outage, not a local inconvenience.
+
+```
+[H 1/N] §<id>  <title>
+  Evidence: <file:line / commit>
+  Suggestion: <suggestion>
+
+  [a]pply / [s]kip / [v]erify-first / [e]vidence / [q]uit
+```
+
+For `low` (non-constraint): skip silently unless the user opted in.
+
+### 5. Apply per category
+
+**Routing rule.** Two paths — this project has no `/backlog` step, so
+"plan-and-gate" means a GitHub issue directly, not a plan file:
+
+- **Issue-and-ship path** for anything touching correctness or the
+  Key Constraints: `constraint-fix`, `code-change`, `update-docs`,
+  `update-tooling`. `gh issue create` with a body citing the dreaming
+  finding, then `/ship <issue-number>`.
+- **Direct branch+PR path** only for `branch-hygiene` cleanup (no code
+  change, just a git-history fix) and `.claude/dreaming/*.sh` script
+  edits that don't touch `CLAUDE.md`'s Key Constraints.
+
+#### `constraint-fix` / `code-change` / `update-docs` / `update-tooling` — issue-and-ship
+
+1. `gh issue create --title "<slug>" --body "..."` citing report
+   `§<id>`, evidence (file:line/commit), suggested fix, acceptance
+   criteria. For `constraint-fix`, explicitly name which Key
+   Constraint is at risk.
+2. Tell the user: "Created issue #<N>. Run `/ship <N>` to implement."
+3. Don't implement directly — `/ship` owns the issue → implement →
+   `/fix-review` → merge → close pipeline.
+
+#### `branch-hygiene` — direct fix, no code change
+
+1. Confirm the branch has a merged PR (`gh pr list --state merged
+   --search "head:<branch>"`).
+2. If a commit landed on it after merge, that commit's changes need to
+   move to a fresh branch off `main` — cherry-pick onto
+   `git checkout main && git pull --ff-only && git checkout -b
+   <new-branch>`, verify, open a fresh PR. Don't leave orphaned commits
+   on the stale branch.
+
+#### `update-tooling` (dreaming script only, not the prompt) — branch+PR
+
+For fixes to `dreaming.sh` itself:
+
+1. `git switch -c fix-dreaming-w##-<slug>` off `main`.
+2. Edit the script; smoke-test with `bash -n .claude/dreaming/dreaming.sh`.
+3. Commit, push, open a PR, merge per the project's normal PR
+   convention.
+
+#### `other` — manual review
+
+Print suggestion + evidence. Don't apply. Annotate
+`[manual-review-required 2026-MM-DD]`.
+
+### 6. Annotate report
+
+After each applied item, append (never rewrite the original):
+
+```markdown
+> [applied 2026-MM-DD: <action>; commit <sha>; PR <num>]
+```
+
+For created issues:
+```markdown
+> [planned 2026-MM-DD: issue #<N>; awaiting /ship]
+```
+
+For skipped:
+```markdown
+> [skipped 2026-MM-DD: <reason>]
+```
+
+### 7. Final summary
+
+```
+Applied: N (direct branch-hygiene / tooling PRs)
+Issues created: M (awaiting /ship)
+Manual review: K
+Skipped: P
+
+PRs opened: <list>
+Issues pending: <list>
+
+Next steps: run /ship on each issue (constraint-fix issues first).
+```
+
+## Constraints (CRITICAL)
+
+- **NEVER commit or push directly to `main`.**
+- **NEVER downgrade a `constraint-fix` item's priority** based on
+  stated confidence — surface it first regardless. This binary's
+  behavior is load-bearing for 8+ other projects' Stop hooks.
+- **NEVER auto-apply low confidence** (non-constraint) without explicit request.
+- **ALWAYS cite report-section** (`§<id>`) in issue bodies, commit
+  messages, and PR bodies.
+- **Confirm before destructive ops** even at high confidence.
+- **Check for the stale-branch anti-pattern** (`CLAUDE.md`'s "Before
+  Any Commit" section) before committing anything onto an existing
+  branch, not just for `branch-hygiene` items.
+
+## Anti-patterns
+
+- ❌ Commit or push to `main` directly, tooling included.
+- ❌ Treat a `constraint-fix` finding as routine — it needs the same
+  scrutiny as a multi-project regression report, not a shrug because
+  the model's confidence label said "low."
+- ❌ Commit onto a branch that already has a merged PR.
+- ❌ Modify the report's original suggestions (annotate only).
+- ❌ Apply a finding without verifying it against current code first.
+
+## Companion skills
+
+- `/ship` — issue → implement → `/fix-review` → merge → close.
+- `/fix-review` — parallel multi-model review + Claude Arbiter (part of `/ship`).
+- `/curate-minions` — the sibling project-tooling skill, same manual-sync convention.
+- `/revival`, `/find-bugs`, `/improve` — complementary read-only checks.
+
+## See also
+
+- `.claude/dreaming/dreaming-prompt.md` — what the dreaming pass looks for.
+- `.claude/dreaming/dreaming.sh` — how the pass is run (systemd timer).
+- `CLAUDE.md` "Key Constraints" section — target of `constraint-fix` findings.

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ docs/superpowers/
 
 tmp/
 sbin/
+
+# dreaming run log (per machine) — reports/ itself IS tracked so the
+# [applied YYYY-MM-DD] annotation trail survives across machines
+.claude/dreaming/reports/.dreaming.log


### PR DESCRIPTION
## Summary
Deploys the weekly-curation system already running across 9 other projects, tailored to this project's own structure:

- `.claude/dreaming/dreaming-prompt.md` — targets `CLAUDE.md`'s Key Constraints (pure-Go/no-CGO, Go 1.26.6+ patch pin, 60s Stop-hook budget, per-project isolation — this binary runs inside 8+ other projects' Stop hooks), `docs/architecture.md`/schema drift, skill-roster overlap, the stale-branch-commit anti-pattern this repo's own CLAUDE.md documents.
- `.claude/dreaming/dreaming.sh` — read-only weekly pass via Ollama.
- `.claude/skills/apply-dreaming/SKILL.md` — this repo has no `/backlog` step; constraint/code/doc findings route through a GitHub issue directly, then `/ship <issue>`. Constraint-violation findings are always surfaced first regardless of stated confidence.
- `.gitignore`: ignore the per-machine dreaming run log.

## Not in this PR
The systemd user timer for the weekly cron — local machine config, added after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)